### PR TITLE
SpotlightLayoutBehavior now calls `attributesDidUpdate`

### DIFF
--- a/Source/Behaviors/SpotlightLayoutBehavior.swift
+++ b/Source/Behaviors/SpotlightLayoutBehavior.swift
@@ -58,6 +58,8 @@ public class SpotlightLayoutBehavior: BrickLayoutBehavior {
                 sectionInset = inset
             }
 
+            var oldFrame = attributes.frame
+
             var originalFrameWithInsets = attributes.originalFrame
             originalFrameWithInsets.size.height = attributes.originalFrame.size.height + sectionInset
 
@@ -117,6 +119,10 @@ public class SpotlightLayoutBehavior: BrickLayoutBehavior {
 
             currentY = attributes.frame.maxY
             previousAttributeWasInSpotlight = isInSpotlight && offsetY >= 0
+
+            if attributes.frame != oldFrame {
+                attributesDidUpdate(attributes: attributes, oldFrame: oldFrame)
+            }
         }
 
         let lastAttribute = scrollAttributes.last! // We can safely unwrap, because we checked the count in the beginning of the function

--- a/Tests/Behaviors/SpotlightLayoutBehaviorTests.swift
+++ b/Tests/Behaviors/SpotlightLayoutBehaviorTests.swift
@@ -306,4 +306,27 @@ class SpotlightLayoutBehaviorTests: BrickFlowLayoutBaseTests {
         thirdRepeatingBrick = layout.layoutAttributesForItemAtIndexPath(NSIndexPath(forItem: 5, inSection: 1))
         XCTAssertEqual(thirdRepeatingBrick?.frame , CGRect(x: 0, y: 390 + secondHeight, width: 320, height: 100))
     }
+
+    func testThatLastBrickIsShowing() {
+        collectionView.registerBrickClass(DummyBrick.self)
+
+        let height:CGFloat = 300
+        let section = BrickSection(bricks: [
+            DummyBrick(height: .Fixed(size: height)),
+            DummyBrick(height: .Fixed(size: height)),
+            DummyBrick(height: .Fixed(size: height)),
+            DummyBrick(height: .Fixed(size: height)),
+            DummyBrick(height: .Fixed(size: height)),
+            DummyBrick(height: .Fixed(size: height)),
+            ])
+
+        behavior = SpotlightLayoutBehavior(dataSource: FixedSpotlightLayoutBehaviorDataSource(height: 50))
+
+        layout.behaviors.insert(behavior)
+
+        collectionView.setSection(section)
+        collectionView.layoutSubviews()
+
+        XCTAssertEqual(collectionView.visibleCells().count, 6)
+    }
 }


### PR DESCRIPTION
Because `attributesDidUpdate` wasn’t called, the `BrickZones` weren’t updated. This resulted in `layoutAttributesForElementsInRect` returning the wrong data
Fixes #4