### PR TITLE
Fix BrickDimension for iPad.

### DIFF
--- a/Source/Models/BrickDimension.swift
+++ b/Source/Models/BrickDimension.swift
@@ -24,11 +24,11 @@ extension UIView: BrickDimensionDeviceInfo {
     }
 
     var horizontalSizeClass: UIUserInterfaceSizeClass {
-        return traitCollection.horizontalSizeClass
+        return UIScreen.mainScreen().traitCollection.horizontalSizeClass
     }
 
     var verticalSizeClass: UIUserInterfaceSizeClass {
-        return traitCollection.verticalSizeClass
+        return UIScreen.mainScreen().traitCollection.verticalSizeClass
     }
 }
 


### PR DESCRIPTION
Use UIScreen.mainScreen's traitCollection instead of UIView.  UIView is not on view hierarchy at time of call, so the trait collections are all unspecified.  This messes up sizing for bricks on iPad.

This commit fixes issue #6 