### PR TITLE
Sticky footer was wrongly calculated

### DIFF
--- a/Example/Source/Examples/BaseBrickController.swift
+++ b/Example/Source/Examples/BaseBrickController.swift
@@ -15,21 +15,21 @@ class BaseBrickController: BrickViewController {
 
     var isBehaviorEnabled = true {
         didSet {
-            updateBehavior()
+            updateBehavior(false)
         }
     }
 
     override func viewWillAppear(animated: Bool) {
         super.viewWillAppear(animated)
         self.view.backgroundColor = .brickBackground
-        updateBehavior()
+        updateBehavior(true)
 
         if self.presentingViewController != nil {
             self.navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .Cancel, target: self, action: #selector(BaseBrickController.close))
         }
     }
 
-    func updateBehavior() {
+    func updateBehavior(onAppear: Bool) {
         guard let behavior = self.behavior else {
             return
         }
@@ -40,6 +40,9 @@ class BaseBrickController: BrickViewController {
         } else {
             self.navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Enable", style: .Plain, target: self, action: selector)
             self.layout.behaviors.remove(behavior)
+        }
+        if !onAppear {
+            self.brickCollectionView.invalidateBricks()
         }
     }
 

--- a/Example/Source/Examples/BaseBrickController.swift
+++ b/Example/Source/Examples/BaseBrickController.swift
@@ -15,21 +15,22 @@ class BaseBrickController: BrickViewController {
 
     var isBehaviorEnabled = true {
         didSet {
-            updateBehavior(false)
+            updateBehavior()
+            self.brickCollectionView.invalidateBricks()
         }
     }
 
     override func viewWillAppear(animated: Bool) {
         super.viewWillAppear(animated)
         self.view.backgroundColor = .brickBackground
-        updateBehavior(true)
+        updateBehavior()
 
         if self.presentingViewController != nil {
             self.navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .Cancel, target: self, action: #selector(BaseBrickController.close))
         }
     }
 
-    func updateBehavior(onAppear: Bool) {
+    func updateBehavior() {
         guard let behavior = self.behavior else {
             return
         }
@@ -40,9 +41,6 @@ class BaseBrickController: BrickViewController {
         } else {
             self.navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Enable", style: .Plain, target: self, action: selector)
             self.layout.behaviors.remove(behavior)
-        }
-        if !onAppear {
-            self.brickCollectionView.invalidateBricks()
         }
     }
 

--- a/Example/Source/Examples/Sticking/StickingFooterBaseViewController.swift
+++ b/Example/Source/Examples/Sticking/StickingFooterBaseViewController.swift
@@ -23,7 +23,6 @@ class StickingFooterBaseViewController: BrickApp.BaseBrickController {
 
     let numberOfLabels = 50
     var repeatLabel: LabelBrick!
-    var titleLabelModel: LabelBrickCellModel!
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -34,25 +33,24 @@ class StickingFooterBaseViewController: BrickApp.BaseBrickController {
 
         self.brickCollectionView.registerBrickClass(LabelBrick.self)
 
-        behavior = StickyFooterLayoutBehavior(dataSource: self)
+        let behavior = StickyFooterLayoutBehavior(dataSource: self)
+        self.brickCollectionView.layout.behaviors.insert(behavior)
 
-        repeatLabel = LabelBrick(BrickIdentifiers.repeatLabel, width: .Ratio(ratio: 0.5), backgroundColor: .brickGray1, dataSource: self)
-        titleLabelModel = LabelBrickCellModel(text: "HEADER")
-
-        let footerSection = BrickSection(StickySection, backgroundColor: .whiteColor(), bricks: [
-            LabelBrick(FooterTitle, backgroundColor: .lightGrayColor(), dataSource: LabelBrickCellModel(text: "Footer Title")),
-            LabelBrick("Label 1", width: .Ratio(ratio: 0.5), backgroundColor: .lightGrayColor(), dataSource: LabelBrickCellModel(text: "Footer Label 1")),
-            LabelBrick("Label 2", width: .Ratio(ratio: 0.5), backgroundColor: .lightGrayColor(), dataSource: LabelBrickCellModel(text: "Footer Label 2")),
+        let footerSection = BrickSection(StickySection, backgroundColor: UIColor.whiteColor(), bricks: [
+            LabelBrick(FooterTitle, backgroundColor: .brickGray1, dataSource: LabelBrickCellModel(text: "Footer Title")),
+            LabelBrick(width: .Ratio(ratio: 0.5), backgroundColor: .lightGrayColor(), dataSource: LabelBrickCellModel(text: "Footer Label 1")),
+            LabelBrick(width: .Ratio(ratio: 0.5), backgroundColor: .lightGrayColor(), dataSource: LabelBrickCellModel(text: "Footer Label 2")),
             ], inset: 5, edgeInsets: UIEdgeInsets(top: 5, left: 5, bottom: 5, right: 5))
 
-        let section = BrickSection("Test", backgroundColor: .whiteColor(), bricks: [
-            repeatLabel,
+        let section = BrickSection(backgroundColor: .whiteColor(), bricks: [
+            LabelBrick(BrickIdentifiers.repeatLabel, width: .Ratio(ratio: 0.5), height: .Auto(estimate: .Fixed(size: 38)), backgroundColor: .brickGray1, dataSource: self),
             footerSection
             ])
         section.repeatCountDataSource = self
 
         self.setSection(section)
     }
+
 }
 
 extension StickingFooterBaseViewController: BrickRepeatCountDataSource {

--- a/Source/Behaviors/StickyFooterLayoutBehavior.swift
+++ b/Source/Behaviors/StickyFooterLayoutBehavior.swift
@@ -25,15 +25,15 @@ public class StickyFooterLayoutBehavior: StickyLayoutBehavior {
         let bottomInset = collectionViewLayout.collectionView!.contentInset.bottom
 
         if isOnFirstSection {
-            collectionViewLayout.collectionView?.scrollIndicatorInsets.bottom = attributes.frame.height  + bottomInset
-            attributes.frame.origin.y = contentBounds.maxY - attributes.frame.size.height - bottomInset
+            collectionViewLayout.collectionView?.scrollIndicatorInsets.bottom = attributes.originalFrame.height  + bottomInset
+            attributes.frame.origin.y = contentBounds.maxY - attributes.originalFrame.size.height - bottomInset
         } else {
-            let y = contentBounds.maxY - attributes.frame.size.height - bottomInset
+            let y = contentBounds.maxY - attributes.originalFrame.size.height - bottomInset
             attributes.frame.origin.y = min(y, attributes.originalFrame.origin.y)
         }
 
         if lastStickyFrame.size != CGSizeZero {
-            attributes.frame.origin.y = min(lastStickyFrame.minY - attributes.frame.height, attributes.originalFrame.origin.y)
+            attributes.frame.origin.y = min(lastStickyFrame.minY - attributes.originalFrame.height, attributes.originalFrame.origin.y)
         }
 
         return !isOnFirstSection

--- a/Source/Layout/BrickFlowLayout.swift
+++ b/Source/Layout/BrickFlowLayout.swift
@@ -357,7 +357,6 @@ extension BrickFlowLayout: BrickLayoutSectionDataSource {
         case .Section(let section):
             if let brickSection = sections?[section] {
                 updateNumberOfItems(brickSection)
-                brickSection.setOrigin(origin, fromBehaviors: false, updatedAttributes: updatedAttributes)
                 if brickSection.sectionWidth != width {
                     brickSection.setSectionWidth(width, updatedAttributes: updatedAttributes)
                 } else if invalidate  {

--- a/Source/Layout/BrickLayout.swift
+++ b/Source/Layout/BrickLayout.swift
@@ -51,6 +51,12 @@ public class BrickLayoutAttributes: UICollectionViewLayoutAttributes {
     }
 }
 
+extension BrickLayoutAttributes {
+    public override var description: String {
+        return super.description + " originalFrame: \(originalFrame); identifier: \(identifier)"
+    }
+}
+
 public protocol BrickLayoutDataSource: class {
     func brickLayout(layout: BrickLayout, widthForItemAtIndexPath indexPath: NSIndexPath, totalWidth: CGFloat, widthRatio: CGFloat) -> CGFloat
     func brickLayout(layout: BrickLayout, estimatedHeightForItemAtIndexPath indexPath: NSIndexPath, containedInWidth width: CGFloat) -> CGFloat

--- a/Tests/Behaviors/StickyFooterLayoutBehaviorTests.swift
+++ b/Tests/Behaviors/StickyFooterLayoutBehaviorTests.swift
@@ -217,5 +217,46 @@ class StickyFooterLayoutBehaviorTests: BrickFlowLayoutBaseTests {
         XCTAssertEqual(secondSectionAttributes?.frame, CGRect(x: 0, y: collectionViewFrame.height - 100 + 500, width: 320, height: 100))
     }
 
+    func testThatFooterSectionDoesNotGrowTooLarge() {
+        collectionView.layout.zIndexBehavior = .BottomUp
+
+        collectionView.registerBrickClass(LabelBrick.self)
+
+        let stickyDataSource = FixedStickyLayoutBehaviorDataSource(indexPaths: [NSIndexPath(forItem: 50, inSection: 1)])
+        let behavior = StickyFooterLayoutBehavior(dataSource: stickyDataSource)
+        collectionView.layout.behaviors.insert(behavior)
+
+        let configureCellBlock: ConfigureLabelBlock  = { cell in
+            cell.edgeInsets.top = 10
+            cell.edgeInsets.bottom = 11
+        }
+
+        let footerSection = BrickSection(bricks: [
+            LabelBrick("A", text: "Footer Title", configureCellBlock: configureCellBlock),
+            LabelBrick("B", width: .Ratio(ratio: 0.5), text: "Footer Label 1", configureCellBlock: configureCellBlock),
+            LabelBrick("C", width: .Ratio(ratio: 0.5), text: "Footer Label 2", configureCellBlock: configureCellBlock),
+            ])
+
+        let section = BrickSection(bricks: [
+            LabelBrick("BRICK", width: .Ratio(ratio: 0.5), height: .Fixed(size: 38), text: "Brick"),
+            footerSection
+            ])
+        let repeatCountDataSource = FixedRepeatCountDataSource(repeatCountHash: ["BRICK" : 50])
+        section.repeatCountDataSource = repeatCountDataSource
+        
+        collectionView.setSection(section)
+        collectionView.layoutSubviews()
+
+        let attributes = collectionView.collectionViewLayout.layoutAttributesForItemAtIndexPath(NSIndexPath(forItem: 50, inSection: 1))
+        XCTAssertEqual(attributes?.frame, CGRect(x: 0, y: 404, width: 320, height: 76))
+
+        let footerAttributes1 = collectionView.collectionViewLayout.layoutAttributesForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 2))
+        XCTAssertEqual(footerAttributes1?.frame, CGRect(x: 0, y: 404, width: 320, height: 38))
+        let footerAttributes2 = collectionView.collectionViewLayout.layoutAttributesForItemAtIndexPath(NSIndexPath(forItem: 1, inSection: 2))
+        XCTAssertEqual(footerAttributes2?.frame, CGRect(x: 0, y: 442, width: 160, height: 38))
+        let footerAttributes3 = collectionView.collectionViewLayout.layoutAttributesForItemAtIndexPath(NSIndexPath(forItem: 2, inSection: 2))
+        XCTAssertEqual(footerAttributes3?.frame, CGRect(x: 160, y: 442, width: 160, height: 38))
+    }
+
     
 }


### PR DESCRIPTION
- StickyFooterLayoutBehavior was still using `frame` instead of `originalFrame` for the calculations
- BrickLayoutSection also needs to take previously calculated bricks into account if the origin had already changed
- Fixed Demo App when enabling/disabling behaviors
- Test

Fixes #8