### PR TITLE
BrickDimension now checks on UIScreen bounds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ script:
   - xcodebuild -showsdks
 
   # Build Framework in Debug and Run Tests if specified
-  - xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES test | xcpretty;
+  - travis_retry xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES test | xcpretty;
 
 after_success:
   - bash <(curl -s https://codecov.io/bash) -J 'BrickKit'

--- a/BrickKit.xcodeproj/project.pbxproj
+++ b/BrickKit.xcodeproj/project.pbxproj
@@ -133,6 +133,8 @@
 		930054031DA724AD00239A13 /* SetZIndexBehaviorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 930054011DA7242800239A13 /* SetZIndexBehaviorTests.swift */; };
 		930054051DA7D8A000239A13 /* BaseBrickCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 930054041DA7D8A000239A13 /* BaseBrickCellTests.swift */; };
 		9303A6D51DA6E00100502803 /* ButtonBrickTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9303A6D41DA6E00100502803 /* ButtonBrickTests.swift */; };
+		933FF95E1DC1207900E0B80E /* Swizzle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 933FF95D1DC1207900E0B80E /* Swizzle.swift */; };
+		933FF95F1DC1207900E0B80E /* Swizzle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 933FF95D1DC1207900E0B80E /* Swizzle.swift */; };
 		9350F0D61DA82A430051235F /* CollectionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9350F0D51DA82A430051235F /* CollectionInfo.swift */; };
 		9361309B1DB83CB7008FFFEF /* CustomBrickCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 935D48D51DB806990091AA39 /* CustomBrickCollectionView.swift */; };
 		9361309C1DB83CB8008FFFEF /* CustomBrickCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 935D48D51DB806990091AA39 /* CustomBrickCollectionView.swift */; };
@@ -282,6 +284,7 @@
 		930054011DA7242800239A13 /* SetZIndexBehaviorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SetZIndexBehaviorTests.swift; sourceTree = "<group>"; };
 		930054041DA7D8A000239A13 /* BaseBrickCellTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseBrickCellTests.swift; sourceTree = "<group>"; };
 		9303A6D41DA6E00100502803 /* ButtonBrickTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ButtonBrickTests.swift; sourceTree = "<group>"; };
+		933FF95D1DC1207900E0B80E /* Swizzle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Swizzle.swift; sourceTree = "<group>"; };
 		9350F0D51DA82A430051235F /* CollectionInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionInfo.swift; sourceTree = "<group>"; };
 		935D48D51DB806990091AA39 /* CustomBrickCollectionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomBrickCollectionView.swift; sourceTree = "<group>"; };
 		9372C5061DA40735007D7EA1 /* FatalErrorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FatalErrorTests.swift; sourceTree = "<group>"; };
@@ -833,6 +836,7 @@
 				93D9EC4D1DA4057900D8C87A /* DataSources.swift */,
 				9372C5061DA40735007D7EA1 /* FatalErrorTests.swift */,
 				93D9EC4E1DA4057900D8C87A /* XCTests.swift */,
+				933FF95D1DC1207900E0B80E /* Swizzle.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -1160,6 +1164,7 @@
 				4E9A25501DABECE300D7EA99 /* ImageBrickTests.swift in Sources */,
 				4E387C571DAEAB380087820E /* BrickAppearBehaviorTests.swift in Sources */,
 				4E9A25651DABECFF00D7EA99 /* DataSources.swift in Sources */,
+				933FF95F1DC1207900E0B80E /* Swizzle.swift in Sources */,
 				4E9A25691DABED0600D7EA99 /* BrickViewControllerTests.swift in Sources */,
 				4E9A25E21DAC2AF400D7EA99 /* DummyBrick.swift in Sources */,
 				4E9A255D1DABECFB00D7EA99 /* BrickCollectionViewDataSourceTests.swift in Sources */,
@@ -1239,6 +1244,7 @@
 				93D9EC841DA4057900D8C87A /* BrickCollectionViewTests.swift in Sources */,
 				93D9EC701DA4057900D8C87A /* AlignRowHeightTests.swift in Sources */,
 				93D9EC7E1DA4057900D8C87A /* Behaviors.swift in Sources */,
+				933FF95E1DC1207900E0B80E /* Swizzle.swift in Sources */,
 				B8B8FFEB1DAD3F4A00A913E9 /* CoverFlowLayoutBehaviorTests.swift in Sources */,
 				93D9EC731DA4057900D8C87A /* BrickFlowLayoutEdgeInsetsTests.swift in Sources */,
 				93D9EC581DA4057900D8C87A /* MaxZIndexBehaviorTests.swift in Sources */,

--- a/Tests/Models/BrickDimensionTests.swift
+++ b/Tests/Models/BrickDimensionTests.swift
@@ -22,6 +22,7 @@ class BrickDimensionTests: XCTestCase {
     override func tearDown() {
         super.tearDown()
         resetScreen()
+        StubScreen.reset()
     }
 
     func testViewPortrait() {
@@ -192,9 +193,19 @@ extension UIScreen {
 }
 
 class StubScreen: UIScreen {
-    static var horizontalSizeClass: UIUserInterfaceSizeClass = .Unspecified
-    static var verticalSizeClass: UIUserInterfaceSizeClass = .Unspecified
-    static var bounds: CGRect = CGRect(x: 0, y: 0, width: 320, height: 480)
+    static let DefaultHorizontalSizeClass: UIUserInterfaceSizeClass = .Unspecified
+    static let DefaultVerticalSizeClass: UIUserInterfaceSizeClass = .Unspecified
+    static let ScreenDefaultBounds = CGRect(x: 0, y: 0, width: 320, height: 480)
+
+    static var horizontalSizeClass: UIUserInterfaceSizeClass = StubScreen.DefaultHorizontalSizeClass
+    static var verticalSizeClass: UIUserInterfaceSizeClass = StubScreen.DefaultVerticalSizeClass
+    static var bounds: CGRect = StubScreen.ScreenDefaultBounds
+
+    static func reset() {
+        StubScreen.horizontalSizeClass = StubScreen.DefaultHorizontalSizeClass
+        StubScreen.verticalSizeClass = StubScreen.DefaultVerticalSizeClass
+        StubScreen.bounds = StubScreen.ScreenDefaultBounds
+    }
 
     override var traitCollection: UITraitCollection {
         return StubTraitCollection()

--- a/Tests/Models/BrickDimensionTests.swift
+++ b/Tests/Models/BrickDimensionTests.swift
@@ -9,29 +9,40 @@
 import XCTest
 @testable import BrickKit
 
-struct TestDeviceInfo: BrickDimensionDeviceInfo {
-    var isPortrait: Bool
-    var horizontalSizeClass: UIUserInterfaceSizeClass
-    var verticalSizeClass: UIUserInterfaceSizeClass
-}
-
 class BrickDimensionTests: XCTestCase {
+    var view: UIView!
 
-    #if os(iOS)
-    func testViewAsDeviceInfo() {
-        let view = UIView()
-        XCTAssertNotNil(view.horizontalSizeClass)
-        XCTAssertNotNil(view.verticalSizeClass)
-        XCTAssertEqual(view.isPortrait, UIDevice.currentDevice().orientation.isPortrait)
+    override func setUp() {
+        super.setUp()
+
+        view = UIView()
+        swizzleScreen()
     }
-    #else
-    func testViewAsDeviceInfo() {
-        let view = UIView()
+
+    override func tearDown() {
+        super.tearDown()
+        resetScreen()
+    }
+
+    func testViewPortrait() {
+        setScreenPortrait(true)
+
         XCTAssertNotNil(view.horizontalSizeClass)
         XCTAssertNotNil(view.verticalSizeClass)
+        XCTAssertTrue(view.isPortrait)
+    }
+
+    func testViewLandscape() {
+        setScreenPortrait(false)
+
         XCTAssertFalse(view.isPortrait)
     }
-    #endif
+
+    func testViewSquare() {
+        StubScreen.bounds.size = CGSize(width: 320, height: 320)
+
+        XCTAssertTrue(view.isPortrait)
+    }
 
     func testFixed() {
         let fixed = BrickDimension.Fixed(size: 50)
@@ -68,56 +79,56 @@ class BrickDimensionTests: XCTestCase {
     }
 
     func testOrientationPortrait() {
-        let deviceInfo = TestDeviceInfo(isPortrait: true, horizontalSizeClass: .Compact, verticalSizeClass: .Compact)
+        setupScreen(isPortrait: true, horizontalSizeClass: .Compact, verticalSizeClass: .Compact)
         let orientation = BrickDimension.Orientation(landscape: BrickDimension.Fixed(size: 100), portrait: BrickDimension.Fixed(size: 50))
-        XCTAssertEqual(orientation.value(for: 1000, in: deviceInfo), 50)
-        XCTAssertEqual(orientation.dimension(in: deviceInfo), BrickDimension.Fixed(size: 50))
+        XCTAssertEqual(orientation.value(for: 1000, in: view), 50)
+        XCTAssertEqual(orientation.dimension(in: view), BrickDimension.Fixed(size: 50))
         XCTAssertEqual(orientation, BrickDimension.Orientation(landscape: BrickDimension.Fixed(size: 100), portrait: BrickDimension.Fixed(size: 50)))
     }
 
     func testOrientationLandscape() {
-        let deviceInfo = TestDeviceInfo(isPortrait: false, horizontalSizeClass: .Compact, verticalSizeClass: .Compact)
+        setupScreen(isPortrait: false, horizontalSizeClass: .Compact, verticalSizeClass: .Compact)
         let orientation = BrickDimension.Orientation(landscape: BrickDimension.Fixed(size: 100), portrait: BrickDimension.Fixed(size: 50))
-        XCTAssertEqual(orientation.value(for: 1000, in: deviceInfo), 100)
-        XCTAssertEqual(orientation.dimension(in: deviceInfo), BrickDimension.Fixed(size: 100))
+        XCTAssertEqual(orientation.value(for: 1000, in: view), 100)
+        XCTAssertEqual(orientation.dimension(in: view), BrickDimension.Fixed(size: 100))
         XCTAssertEqual(orientation, BrickDimension.Orientation(landscape: BrickDimension.Fixed(size: 100), portrait: BrickDimension.Fixed(size: 50)))
     }
 
     func testHorizontalSizeClassCompact() {
-        let deviceInfo = TestDeviceInfo(isPortrait: true, horizontalSizeClass: .Compact, verticalSizeClass: .Regular)
+        setupScreen(isPortrait: true, horizontalSizeClass: .Compact, verticalSizeClass: .Regular)
         let sizeClass = BrickDimension.HorizontalSizeClass(regular: BrickDimension.Fixed(size: 100), compact: BrickDimension.Fixed(size: 50))
-        XCTAssertEqual(sizeClass.value(for: 1000, in: deviceInfo), 50)
-        XCTAssertEqual(sizeClass.dimension(in: deviceInfo), BrickDimension.Fixed(size: 50))
+        XCTAssertEqual(sizeClass.value(for: 1000, in: view), 50)
+        XCTAssertEqual(sizeClass.dimension(in: view), BrickDimension.Fixed(size: 50))
         XCTAssertEqual(sizeClass, BrickDimension.HorizontalSizeClass(regular: BrickDimension.Fixed(size: 100), compact: BrickDimension.Fixed(size: 50)))
 
     }
 
     func testHorizontalSizeClassRegular() {
-        let deviceInfo = TestDeviceInfo(isPortrait: true, horizontalSizeClass: .Regular, verticalSizeClass: .Compact)
+        setupScreen(isPortrait: true, horizontalSizeClass: .Regular, verticalSizeClass: .Compact)
         let sizeClass = BrickDimension.HorizontalSizeClass(regular: BrickDimension.Fixed(size: 100), compact: BrickDimension.Fixed(size: 50))
-        XCTAssertEqual(sizeClass.value(for: 1000, in: deviceInfo), 100)
-        XCTAssertEqual(sizeClass.dimension(in: deviceInfo), BrickDimension.Fixed(size: 100))
+        XCTAssertEqual(sizeClass.value(for: 1000, in: view), 100)
+        XCTAssertEqual(sizeClass.dimension(in: view), BrickDimension.Fixed(size: 100))
         XCTAssertEqual(sizeClass, BrickDimension.HorizontalSizeClass(regular: BrickDimension.Fixed(size: 100), compact: BrickDimension.Fixed(size: 50)))
     }
 
     func testVerticalSizeClassCompact() {
-        let deviceInfo = TestDeviceInfo(isPortrait: true, horizontalSizeClass: .Regular, verticalSizeClass: .Compact)
+        setupScreen(isPortrait: true, horizontalSizeClass: .Regular, verticalSizeClass: .Compact)
         let sizeClass = BrickDimension.VerticalSizeClass(regular: BrickDimension.Fixed(size: 100), compact: BrickDimension.Fixed(size: 50))
-        XCTAssertEqual(sizeClass.value(for: 1000, in: deviceInfo), 50)
-        XCTAssertEqual(sizeClass.dimension(in: deviceInfo), BrickDimension.Fixed(size: 50))
+        XCTAssertEqual(sizeClass.value(for: 1000, in: view), 50)
+        XCTAssertEqual(sizeClass.dimension(in: view), BrickDimension.Fixed(size: 50))
         XCTAssertEqual(sizeClass, BrickDimension.VerticalSizeClass(regular: BrickDimension.Fixed(size: 100), compact: BrickDimension.Fixed(size: 50)))
     }
 
     func testVerticalSizeClassRegular() {
-        let deviceInfo = TestDeviceInfo(isPortrait: true, horizontalSizeClass: .Compact, verticalSizeClass: .Regular)
+        setupScreen(isPortrait: true, horizontalSizeClass: .Compact, verticalSizeClass: .Regular)
         let sizeClass = BrickDimension.VerticalSizeClass(regular: BrickDimension.Fixed(size: 100), compact: BrickDimension.Fixed(size: 50))
-        XCTAssertEqual(sizeClass.value(for: 1000, in: deviceInfo), 100)
-        XCTAssertEqual(sizeClass.dimension(in: deviceInfo), BrickDimension.Fixed(size: 100))
+        XCTAssertEqual(sizeClass.value(for: 1000, in: view), 100)
+        XCTAssertEqual(sizeClass.dimension(in: view), BrickDimension.Fixed(size: 100))
         XCTAssertEqual(sizeClass, BrickDimension.VerticalSizeClass(regular: BrickDimension.Fixed(size: 100), compact: BrickDimension.Fixed(size: 50)))
     }
 
     func testNestedPortraitCompact() {
-        let deviceInfo = TestDeviceInfo(isPortrait: true, horizontalSizeClass: .Compact, verticalSizeClass: .Regular)
+        setupScreen(isPortrait: true, horizontalSizeClass: .Compact, verticalSizeClass: .Regular)
 
         let nested = BrickDimension.Orientation(
             landscape: .Fixed(size: 50),
@@ -125,9 +136,9 @@ class BrickDimensionTests: XCTestCase {
                 regular: .Auto(estimate: .Fixed(size: 100)),
                 compact: .Auto(estimate: .Fixed(size: 50))
             ))
-        XCTAssertEqual(nested.value(for: 1000, in: deviceInfo), 50)
-        XCTAssertEqual(nested.dimension(in: deviceInfo), BrickDimension.Auto(estimate: BrickDimension.Fixed(size: 50)))
-        XCTAssertTrue(nested._isEstimate(in: deviceInfo))
+        XCTAssertEqual(nested.value(for: 1000, in: view), 50)
+        XCTAssertEqual(nested.dimension(in: view), BrickDimension.Auto(estimate: BrickDimension.Fixed(size: 50)))
+        XCTAssertTrue(nested.isEstimate(in: view))
         XCTAssertEqual(nested, BrickDimension.Orientation(
             landscape: .Fixed(size: 50),
             portrait: .HorizontalSizeClass(
@@ -144,3 +155,63 @@ class BrickDimensionTests: XCTestCase {
     }
 
 }
+
+// MARK: - Utility methods to `fake` UIScreen.mainScreen
+extension BrickDimensionTests {
+
+    /// Setup UIScreen.mainScreen to call a different method
+    func swizzleScreen() {
+        NSObject.swizzleStaticMethodSelector(#selector(UIScreen.mainScreen), withSelector: #selector(UIScreen.stubMainScreen), forClass: UIScreen.self)
+    }
+
+    /// Reset UIScreen.mainScreen to call a different method
+    func resetScreen() {
+        NSObject.swizzleStaticMethodSelector(#selector(UIScreen.stubMainScreen), withSelector: #selector(UIScreen.mainScreen), forClass: UIScreen.self)
+    }
+
+    /// Setup the UIScreen for the given test
+    func setupScreen(isPortrait isPortrait: Bool, horizontalSizeClass: UIUserInterfaceSizeClass, verticalSizeClass: UIUserInterfaceSizeClass) {
+        StubScreen.horizontalSizeClass = horizontalSizeClass
+        StubScreen.verticalSizeClass = verticalSizeClass
+        setScreenPortrait(isPortrait)
+    }
+
+    func setScreenPortrait(isPortrait: Bool) {
+        StubScreen.bounds.size = isPortrait ? CGSize(width: 320, height: 480) : CGSize(width: 480, height: 320)
+    }
+
+}
+
+
+// Mark: - Screen
+
+extension UIScreen {
+    @objc class func stubMainScreen() -> UIScreen {
+        return StubScreen()
+    }
+}
+
+class StubScreen: UIScreen {
+    static var horizontalSizeClass: UIUserInterfaceSizeClass = .Unspecified
+    static var verticalSizeClass: UIUserInterfaceSizeClass = .Unspecified
+    static var bounds: CGRect = CGRect(x: 0, y: 0, width: 320, height: 480)
+
+    override var traitCollection: UITraitCollection {
+        return StubTraitCollection()
+    }
+
+    override var bounds: CGRect {
+        return StubScreen.bounds
+    }
+    
+}
+
+class StubTraitCollection: UITraitCollection {
+    override var horizontalSizeClass: UIUserInterfaceSizeClass {
+        return StubScreen.horizontalSizeClass
+    }
+    override var verticalSizeClass: UIUserInterfaceSizeClass {
+        return StubScreen.verticalSizeClass
+    }
+}
+

--- a/Tests/Utils/Swizzle.swift
+++ b/Tests/Utils/Swizzle.swift
@@ -1,0 +1,45 @@
+//
+//  Swizzle.swift
+//  BrickKit
+//
+//  Created by Ruben Cagnie on 10/26/16.
+//  Copyright © 2016 Wayfair. All rights reserved.
+//
+
+import Foundation
+
+// Allow tests to `swizzle` methods to methods that are unreachable, so we can simulate device behaviors
+
+extension NSObject {
+
+    class func swizzleMethodSelector(origSelector: Selector, withSelector: Selector, forClass:AnyClass!) -> Bool {
+
+        var originalMethod: Method?
+        var swizzledMethod: Method?
+
+        originalMethod = class_getInstanceMethod(forClass, origSelector)
+        swizzledMethod = class_getInstanceMethod(forClass, withSelector)
+
+        if (originalMethod != nil && swizzledMethod != nil) {
+            method_exchangeImplementations(originalMethod!, swizzledMethod!)
+            return true
+        }
+        return false
+    }
+
+    class func swizzleStaticMethodSelector(origSelector: Selector, withSelector: Selector, forClass:AnyClass!) -> Bool {
+
+        var originalMethod: Method?
+        var swizzledMethod: Method?
+
+        originalMethod = class_getClassMethod(forClass, origSelector)
+        swizzledMethod = class_getClassMethod(forClass, withSelector)
+
+        if (originalMethod != nil && swizzledMethod != nil) {
+            method_exchangeImplementations(originalMethod!, swizzledMethod!)
+            return true
+        }
+        return false
+    }
+
+}


### PR DESCRIPTION
- Check for orientation is now done on `UIScreen.mainScreen().bounds`
- Added tests that swizzle `UIScreen.mainScreen()`

Fixes #13