### PR TITLE
Wrapped `updateHeight` in `performBatchUpdates`

### DIFF
--- a/Source/ViewControllers/BrickCollectionView.swift
+++ b/Source/ViewControllers/BrickCollectionView.swift
@@ -499,7 +499,9 @@ extension BrickCollectionView: UICollectionViewDataSource {
                 resizable.sizeChangedHandler = { [weak collectionView] cell in
                     let height = cell.heightForBrickView(withWidth: brickCell.frame.width)
                     if let brickCollectionView = collectionView as? BrickCollectionView, let flow = brickCollectionView.layout as? BrickFlowLayout {
-                        flow.updateHeight(indexPath, newHeight: height)
+                        brickCollectionView.performBatchUpdates({ 
+                            flow.updateHeight(indexPath, newHeight: height)
+                            }, completion: nil)
                     }
                 }
             }

--- a/Tests/Bricks/CollectionBrickTests.swift
+++ b/Tests/Bricks/CollectionBrickTests.swift
@@ -95,6 +95,14 @@ class CollectionBrickTests: XCTestCase {
         brickView.setSection(section)
         brickView.layoutSubviews()
 
+        let expectation = expectationWithDescription("Wait for batch updates")
+        brickView.performBatchUpdates({ 
+            // Run this inside a performBatchUpdates, so this is called after the sizeChangeHandler was called
+            }) { (completed) in
+                expectation.fulfill()
+        }
+        waitForExpectationsWithTimeout(5, handler: nil)
+
         let cell1 = brickView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 1)) as? CollectionBrickCell
         cell1?.layoutIfNeeded()
         XCTAssertEqual(cell1?.brickCollectionView.frame, CGRect(x: 0, y: 0, width: 320, height: 320 * 8))


### PR DESCRIPTION
The `updateHeight` call is now wrapped in a `performBatchUpdates`, so the UI will always be updated

Fixes #15