### PR TITLE
Reported changed attributes correctly

### DIFF
--- a/Source/Layout/BrickLayoutSection.swift
+++ b/Source/Layout/BrickLayoutSection.swift
@@ -308,7 +308,7 @@ internal class BrickLayoutSection {
             if shouldBeOnNextRow {
                 if dataSource.alignRowHeights {
                     let maxHeight = maxY - y
-                    updateHeightForRowsFromIndex(index - 1, maxHeight: maxHeight)
+                    updateHeightForRowsFromIndex(index - 1, maxHeight: maxHeight, updatedAttributes: updatedAttributes)
                 }
 
                 if maxY > y  {
@@ -359,7 +359,7 @@ internal class BrickLayoutSection {
 
         if dataSource.alignRowHeights {
             let maxHeight = maxY - y
-            updateHeightForRowsFromIndex(attributes.count - 1, maxHeight: maxHeight)
+            updateHeightForRowsFromIndex(attributes.count - 1, maxHeight: maxHeight, updatedAttributes: updatedAttributes)
         }
 
         var frameHeight: CGFloat = 0
@@ -393,7 +393,7 @@ internal class BrickLayoutSection {
         }        
     }
 
-    func updateHeightForRowsFromIndex(index: Int, maxHeight: CGFloat) {
+    func updateHeightForRowsFromIndex(index: Int, maxHeight: CGFloat, updatedAttributes: OnAttributesUpdatedHandler?) {
         guard index >= 0 else {
             return
         }
@@ -403,7 +403,11 @@ internal class BrickLayoutSection {
             if attributes[currentIndex].originalFrame.origin.y != y {
                 return
             }
+            let oldFrame = attributes[currentIndex].frame
             attributes[currentIndex].frame.size.height = maxHeight
+            if attributes[currentIndex].frame != oldFrame {
+                updatedAttributes?(attributes: attributes[currentIndex], oldFrame: oldFrame)
+            }
             currentIndex -= 1
         }
     }


### PR DESCRIPTION
When an attribute gets updated because a height, it will also update the whole row, so the heights are aligned.
When doing so, the attributes that were updated, were not properly registered, hence never filled into the `invalidatedItemIndexPaths` array. This caused the collectionView NOT to update that attribute.

This is fixed by registering those attributes as well

Fixes #17