### PR TITLE
Fixed wrong contentSize when Brick’s height changed

### DIFF
--- a/Example/Source/Examples/Interactive/InvalidateHeightViewController.swift
+++ b/Example/Source/Examples/Interactive/InvalidateHeightViewController.swift
@@ -33,7 +33,10 @@ class InvalidateHeightViewController: BrickViewController {
             })
 
         let section = BrickSection(bricks: [
-            brick
+            brick,
+            LabelBrick(BrickIdentifiers.repeatLabel, backgroundColor: .brickGray2, dataSource: LabelBrickCellModel(text: "BRICK", configureCellBlock: { cell in
+                cell.configure()
+                }))
             ], inset: 10, edgeInsets: UIEdgeInsets(top: 20, left: 20, bottom: 20, right: 20))
 
         self.setSection(section)

--- a/Source/Layout/BrickLayoutSection.swift
+++ b/Source/Layout/BrickLayoutSection.swift
@@ -255,8 +255,10 @@ internal class BrickLayoutSection {
                     startOrigin = CGPoint(x: lastAttribute.originalFrame.maxX + inset, y: lastAttribute.originalFrame.origin.y)
                 }
             } else if let first = visibleAttributes.first, let firstAttributesIndex = visibleAttributes.indexOf(first) where firstAttributesIndex <= firstIndex {
-                maxY = first.originalFrame.maxY
-                startOrigin = first.originalFrame.origin
+                if !invalidate {
+                    maxY = first.originalFrame.maxY
+                    startOrigin = first.originalFrame.origin
+                }
             }
         }
 

--- a/Tests/ViewControllers/BrickCollectionViewTests.swift
+++ b/Tests/ViewControllers/BrickCollectionViewTests.swift
@@ -412,4 +412,87 @@ class BrickCollectionViewTests: XCTestCase {
         let cell2 = brickView.cellForItemAtIndexPath(NSIndexPath(forItem: 1, inSection: 1))
         XCTAssertEqual(cell2?.frame, CGRect(x: 0, y: 80, width: 320, height: 160))
     }
+
+    func testThatBricksBelowABrickThatShrunkAreOnTheRightYOrigin() {
+
+        let brickView = BrickCollectionView(frame: CGRect(x: 0, y: 0, width: 320, height: 480))
+        brickView.registerBrickClass(DummyBrick.self)
+        let brick = DummyBrick("resizeBrick", height: .Fixed(size: 150))
+        let section = BrickSection("TestSection", bricks:[
+            brick,
+            DummyBrick("secondBrick", height: .Fixed(size: 25))
+            ])
+        brickView.setSection(section)
+        brickView.layoutSubviews()
+
+        var height = brickView.contentSize.height
+        XCTAssertEqual(height, 175)
+        var cell1 = brickView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 1))
+        XCTAssertEqual(cell1?.frame, CGRect(x: 0, y: 0, width: 320, height: 150))
+        var cell2 = brickView.cellForItemAtIndexPath(NSIndexPath(forItem: 1, inSection: 1))
+        XCTAssertEqual(cell2?.frame, CGRect(x: 0, y: 150, width: 320, height: 25))
+
+        brick.height = .Fixed(size: 100)
+        let expectation = expectationWithDescription("")
+
+        brickView.invalidateBricks { (completed) in
+            expectation.fulfill()
+        }
+
+        waitForExpectationsWithTimeout(1, handler: nil)
+        brickView.layoutIfNeeded()
+
+        height = brickView.contentSize.height
+        XCTAssertEqual(height, 125)
+
+        cell1 = brickView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 1))
+        XCTAssertEqual(cell1?.frame, CGRect(x: 0, y: 0, width: 320, height: 100))
+        cell2 = brickView.cellForItemAtIndexPath(NSIndexPath(forItem: 1, inSection: 1))
+        XCTAssertEqual(cell2?.frame, CGRect(x: 0, y: 100, width: 320, height: 25))
+    }
+
+    func testThatBricksBelowABrickThatShrunkAreOnTheRightYOriginFromSecondBrick() {
+
+        let brickView = BrickCollectionView(frame: CGRect(x: 0, y: 0, width: 320, height: 480))
+        brickView.registerBrickClass(DummyBrick.self)
+        let brick = DummyBrick("resizeBrick", height: .Fixed(size: 150))
+        let section = BrickSection("TestSection", bricks:[
+            DummyBrick("secondBrick", height: .Fixed(size: 25)),
+            brick,
+            DummyBrick("secondBrick", height: .Fixed(size: 25))
+            ])
+        brickView.setSection(section)
+        brickView.layoutSubviews()
+
+        var height = brickView.contentSize.height
+        XCTAssertEqual(height, 200)
+        var cell1 = brickView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 1))
+        XCTAssertEqual(cell1?.frame, CGRect(x: 0, y: 0, width: 320, height: 25))
+        var cell2 = brickView.cellForItemAtIndexPath(NSIndexPath(forItem: 1, inSection: 1))
+        XCTAssertEqual(cell2?.frame, CGRect(x: 0, y: 25, width: 320, height: 150))
+        var cell3 = brickView.cellForItemAtIndexPath(NSIndexPath(forItem: 2, inSection: 1))
+        XCTAssertEqual(cell3?.frame, CGRect(x: 0, y: 175, width: 320, height: 25))
+
+        brick.height = .Fixed(size: 100)
+        let expectation = expectationWithDescription("")
+
+        brickView.invalidateBricks { (completed) in
+            expectation.fulfill()
+        }
+
+        waitForExpectationsWithTimeout(1, handler: nil)
+        brickView.layoutIfNeeded()
+
+        height = brickView.contentSize.height
+        XCTAssertEqual(height, 150)
+
+        cell1 = brickView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 1))
+        XCTAssertEqual(cell1?.frame, CGRect(x: 0, y: 0, width: 320, height: 25))
+        cell2 = brickView.cellForItemAtIndexPath(NSIndexPath(forItem: 1, inSection: 1))
+        XCTAssertEqual(cell2?.frame, CGRect(x: 0, y: 25, width: 320, height: 100))
+        cell3 = brickView.cellForItemAtIndexPath(NSIndexPath(forItem: 2, inSection: 1))
+        XCTAssertEqual(cell3?.frame, CGRect(x: 0, y: 125, width: 320, height: 25))
+    }
+
+
 }


### PR DESCRIPTION
The algoritm to check the max Y of a row was not taking in account an `invalidation`

Fixes #36