### PR TITLE
alignRowHeights per BrickSection

### DIFF
--- a/Example/Source/Examples/HorizontalScroll/HorizontalCollectionViewController.swift
+++ b/Example/Source/Examples/HorizontalScroll/HorizontalCollectionViewController.swift
@@ -35,15 +35,13 @@ class HorizontalCollectionViewController: BrickViewController {
 
         self.view.backgroundColor = .brickBackground
 
-        self.brickCollectionView.layout.alignRowHeights = true
-
         collectionSection = BrickSection(bricks: [
             ImageBrick(width: .Ratio(ratio: 1/2), height: .Ratio(ratio: 1), dataSource: self),
             BrickSection(width: .Ratio(ratio: 1/2), bricks: [
                 LabelBrick(RepeatCollectionBrickViewController.Identifiers.titleLabel, backgroundColor: .brickGray2, dataSource: self),
                 LabelBrick(RepeatCollectionBrickViewController.Identifiers.subTitleLabel, backgroundColor: .brickGray4, dataSource: self)
                 ])
-            ], inset: 10, edgeInsets: UIEdgeInsets(top: 5, left: 5, bottom: 5, right: 5))
+            ], inset: 10, edgeInsets: UIEdgeInsets(top: 5, left: 5, bottom: 5, right: 5), alignRowHeights: true)
 
         self.registerBrickClass(CollectionBrick.self)
 

--- a/Example/Source/Examples/Simple/SimpleRepeatBrickViewController.swift
+++ b/Example/Source/Examples/Simple/SimpleRepeatBrickViewController.swift
@@ -25,8 +25,6 @@ class SimpleRepeatBrickViewController: BrickViewController, LabelBrickCellDataSo
 
         self.brickCollectionView.registerBrickClass(LabelBrick.self)
 
-        self.layout.alignRowHeights = false
-
         self.view.backgroundColor = .brickBackground
 
         let section = BrickSection(bricks: [
@@ -41,12 +39,12 @@ class SimpleRepeatBrickViewController: BrickViewController, LabelBrickCellDataSo
 
     func updateNavigationItem() {
         let selector: Selector = #selector(SimpleRepeatBrickViewController.toggleAlignBehavior)
-        let title = self.layout.alignRowHeights ? "Don't Align" : "Align"
+        let title = self.brickCollectionView.section.alignRowHeights ? "Don't Align" : "Align"
         self.navigationItem.rightBarButtonItem = UIBarButtonItem(title: title, style: .Plain, target: self, action: selector)
     }
 
     func toggleAlignBehavior() {
-        self.layout.alignRowHeights = !self.layout.alignRowHeights
+        self.brickCollectionView.section.alignRowHeights = !self.brickCollectionView.section.alignRowHeights
         brickCollectionView.reloadData()
         updateNavigationItem()
     }

--- a/Example/Source/Examples/Sticking/StickingFooterSectionsViewController.swift
+++ b/Example/Source/Examples/Sticking/StickingFooterSectionsViewController.swift
@@ -31,8 +31,6 @@ class StickingFooterSectionsViewController: BrickApp.BaseBrickController {
 
         self.brickCollectionView.registerBrickClass(LabelBrick.self)
 
-        self.layout.alignRowHeights = true
-
         behavior = StickyFooterLayoutBehavior(dataSource: self)
 
         repeatLabel = LabelBrick(BrickIdentifiers.repeatLabel, width: .Ratio(ratio:0.5), backgroundColor:.lightGrayColor(), dataSource:self)

--- a/Example/Source/Examples/Sticking/StickingSectionsViewController.swift
+++ b/Example/Source/Examples/Sticking/StickingSectionsViewController.swift
@@ -32,8 +32,6 @@ class StickingSectionsViewController: BrickApp.BaseBrickController {
 
         self.brickCollectionView.registerBrickClass(LabelBrick.self)
 
-        self.layout.alignRowHeights = true
-
         behavior = StickyLayoutBehavior(dataSource: self)
 
         repeatLabel = LabelBrick(BrickIdentifiers.repeatLabel, width: .Ratio(ratio: 0.5), backgroundColor: .brickGray1, dataSource: self)

--- a/Source/Layout/BrickFlowLayout.swift
+++ b/Source/Layout/BrickFlowLayout.swift
@@ -22,9 +22,6 @@ public class BrickFlowLayout: UICollectionViewLayout, BrickLayout {
         return collectionView?.superview?.superview is CollectionBrickCell
     }
 
-    /// Align Rowheights
-    public var alignRowHeights: Bool = false
-
     public var behaviors: Set<BrickLayoutBehavior> = [] {
         didSet {
             for behavior in behaviors {
@@ -385,6 +382,10 @@ extension BrickFlowLayout: BrickLayoutSectionDataSource {
 
     func inset(in section: BrickLayoutSection) -> CGFloat {
         return _dataSource.brickLayout(self, insetForSection: section.sectionIndex)
+    }
+
+    func isAlignRowHeights(in section: BrickLayoutSection) -> Bool {
+        return _dataSource.brickLayout(self, isAlignRowHeightsForSection: section.sectionIndex)
     }
 
     func identifier(for index: Int, in section: BrickLayoutSection) -> String {

--- a/Source/Layout/BrickLayout.swift
+++ b/Source/Layout/BrickLayout.swift
@@ -16,7 +16,6 @@ public protocol BrickLayout: class {
     var contentSize: CGSize { get }
     var zIndexBehavior: BrickLayoutZIndexBehavior { get set }
     var maxZIndex: Int { get }
-    var alignRowHeights: Bool { get set }
     var scrollDirection: UICollectionViewScrollDirection { get set }
 
     weak var dataSource: BrickLayoutDataSource? { get set }
@@ -86,6 +85,7 @@ public protocol BrickLayoutDataSource: class {
     func brickLayout(layout: BrickLayout, estimatedHeightForItemAtIndexPath indexPath: NSIndexPath, containedInWidth width: CGFloat) -> CGFloat
     func brickLayout(layout: BrickLayout, edgeInsetsForSection section: Int) -> UIEdgeInsets
     func brickLayout(layout: BrickLayout, insetForSection section: Int) -> CGFloat
+    func brickLayout(layout: BrickLayout, isAlignRowHeightsForSection section: Int) -> Bool
     func brickLayout(layout: BrickLayout, brickLayoutTypeForItemAtIndexPath indexPath: NSIndexPath) -> BrickLayoutType
     func brickLayout(layout: BrickLayout, identifierForIndexPath indexPath: NSIndexPath) -> String
     func brickLayout(layout: BrickLayout, indexPathForSection section: Int) -> NSIndexPath?
@@ -102,6 +102,10 @@ extension BrickLayoutDataSource {
         return true
     }
 
+    func brickLayout(layout: BrickLayout, isAlignRowHeightsForSection section: Int) -> Bool {
+        return false
+    }
+    
 }
 
 public protocol BrickLayoutDelegate: class {

--- a/Source/Layout/BrickLayoutSection.swift
+++ b/Source/Layout/BrickLayoutSection.swift
@@ -14,10 +14,6 @@ protocol BrickLayoutSectionDelegate: class {
 
 protocol BrickLayoutSectionDataSource: class {
 
-    /// Indicates if the rows need to be aligned
-    var alignRowHeights: Bool { get }
-
-
     /// Scroll Direction of the layout
     var scrollDirection: UICollectionViewScrollDirection { get }
 
@@ -30,6 +26,9 @@ protocol BrickLayoutSectionDataSource: class {
     /// The inset for this section
     func inset(in section: BrickLayoutSection) -> CGFloat
 
+    /// Flag that indicates if row heights need to be aligned
+    func isAlignRowHeights(in section: BrickLayoutSection) -> Bool
+
     /// Function called right before the height is asked. This can be used to do some other pre-calcuations
     func prepareForSizeCalculation(for attributes: BrickLayoutAttributes, containedIn width: CGFloat, origin: CGPoint, invalidate: Bool, in section: BrickLayoutSection, updatedAttributes: OnAttributesUpdatedHandler?)
 
@@ -39,7 +38,6 @@ protocol BrickLayoutSectionDataSource: class {
     ///   - totalWidth: width minus the edgeinsets
     /// - Returns: width for attributes at a given index
     func width(for index: Int, totalWidth: CGFloat, startingAt origin: CGFloat, in section: BrickLayoutSection) -> CGFloat
-
 
     /// Returns the size for attributes at a given index
     func size(for attributes: BrickLayoutAttributes, containedIn width: CGFloat, in section: BrickLayoutSection) -> CGSize
@@ -311,7 +309,7 @@ internal class BrickLayoutSection {
         }
 
         // If rows need to be aligned, make sure the previous lines are checked
-        if dataSource.alignRowHeights && dataSource.scrollDirection == .Vertical {
+        if dataSource.isAlignRowHeights(in: self) && dataSource.scrollDirection == .Vertical {
             let maxHeight = maxY - y
             updateHeightForRowsFromIndex(attributes.count - 1, maxHeight: maxHeight, updatedAttributes: updatedAttributes)
         }
@@ -473,7 +471,7 @@ internal class BrickLayoutSection {
         var nextY: CGFloat = y
         var nextX: CGFloat = x
         if shouldBeOnNextRow {
-            if dataSource.alignRowHeights && dataSource.scrollDirection == .Vertical {
+            if dataSource.isAlignRowHeights(in: self) && dataSource.scrollDirection == .Vertical {
                 let maxHeight = maxY - nextY
                 updateHeightForRowsFromIndex(index - 1, maxHeight: maxHeight, updatedAttributes: updatedAttributes)
             }
@@ -551,7 +549,6 @@ internal class BrickLayoutSection {
             height = size.height
             width = size.width
         }
-
 
         var brickFrame = CGRect(origin: cellOrigin, size: CGSize(width: width, height: height))
 

--- a/Source/Models/BrickModels.swift
+++ b/Source/Models/BrickModels.swift
@@ -104,6 +104,7 @@ public class BrickSection: Brick {
     public var bricks: [Brick]
     public var inset: CGFloat
     public var edgeInsets: UIEdgeInsets
+    public var alignRowHeights: Bool
 
     internal private(set) var collectionIndex: Int = 0
     internal private(set) var collectionIdentifier: String = ""
@@ -117,10 +118,11 @@ public class BrickSection: Brick {
         }
     }
 
-    public init(_ identifier: String = "", width: BrickDimension = .Ratio(ratio: 1), height: BrickDimension = .Auto(estimate: .Fixed(size: 0)), backgroundColor: UIColor = .clearColor(), backgroundView: UIView? = nil, bricks: [Brick], inset: CGFloat = 0, edgeInsets: UIEdgeInsets = UIEdgeInsetsZero) {
+    public init(_ identifier: String = "", width: BrickDimension = .Ratio(ratio: 1), height: BrickDimension = .Auto(estimate: .Fixed(size: 0)), backgroundColor: UIColor = .clearColor(), backgroundView: UIView? = nil, bricks: [Brick], inset: CGFloat = 0, edgeInsets: UIEdgeInsets = UIEdgeInsetsZero, alignRowHeights: Bool = false) {
         self.bricks = bricks
         self.inset = inset
         self.edgeInsets = edgeInsets
+        self.alignRowHeights = alignRowHeights
         super.init(identifier, width: width, height: height, backgroundColor: backgroundColor, backgroundView: backgroundView)
     }
 

--- a/Source/ViewControllers/BrickCollectionView+BrickLayoutDataSource.swift
+++ b/Source/ViewControllers/BrickCollectionView+BrickLayoutDataSource.swift
@@ -61,6 +61,16 @@ extension BrickCollectionView: BrickLayoutDataSource {
         return brickSection.inset
     }
 
+    public func brickLayout(layout: BrickLayout, isAlignRowHeightsForSection section: Int) -> Bool {
+        guard
+            let indexPath = self.section.indexPathForSection(section, in: collectionInfo),
+            let brickSection = self.brick(at:indexPath) as? BrickSection
+            else {
+                return false
+        }
+        return brickSection.alignRowHeights
+    }
+
     public func brickLayout(layout: BrickLayout, brickLayoutTypeForItemAtIndexPath indexPath: NSIndexPath) -> BrickLayoutType {
         let brick = self.brick(at:indexPath)
         if brick is BrickSection {

--- a/Tests/Layout/AlignRowHeightTests.swift
+++ b/Tests/Layout/AlignRowHeightTests.swift
@@ -12,80 +12,70 @@ import XCTest
 class AlignRowHeightTests: BrickFlowLayoutBaseTests {
 
     func testAlignRowHeightsSingleRow() {
-        collectionView.layout.alignRowHeights = true
 
-        let half = CGFloat(1.0/2.0)
-        setDataSources(SectionsCollectionViewDataSource(sections: [2]), brickLayoutDataSource: SectionsLayoutDataSource(widthRatios: [[half, half]], heights: [[100, 200]], types: [[.Brick, .Brick]]))
+        collectionView.registerBrickClass(DummyBrick.self)
 
+        let section = BrickSection(bricks: [
+            DummyBrick(width: .Ratio(ratio: 1/2), height: .Fixed(size: 100)),
+            DummyBrick(width: .Ratio(ratio: 1/2), height: .Fixed(size: 200))
+            ], alignRowHeights: true)
+        collectionView.setSection(section)
+        collectionView.layoutSubviews()
 
-        let expectedResult = [
-            0 : [
-                CGRect(x: 0, y: 0, width: 160, height: 200),
-                CGRect(x: 160, y: 0, width: 160, height: 200),
-            ]
-        ]
-
-        let attributes = layout.layoutAttributesForElementsInRect(collectionViewFrame)
-        XCTAssertNotNil(attributes)
-        XCTAssertTrue(verifyAttributesToExpectedResult(attributes!, expectedResult: expectedResult))
+        let cell1 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 1))
+        XCTAssertEqual(cell1?.frame, CGRect(x: 0, y: 0, width: 160, height: 200))
+        let cell2 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 1, inSection: 1))
+        XCTAssertEqual(cell2?.frame, CGRect(x: 160, y: 0, width: 160, height: 200))
     }
 
     func testAlignRowHeightsSingleRowFirstRowHighest() {
-        collectionView.layout.alignRowHeights = true
+        collectionView.registerBrickClass(DummyBrick.self)
 
-        let half = CGFloat(1.0/2.0)
-        setDataSources(SectionsCollectionViewDataSource(sections: [2]), brickLayoutDataSource: SectionsLayoutDataSource(widthRatios: [[half, half]], heights: [[200, 100]], types: [[.Brick, .Brick]]))
+        let section = BrickSection(bricks: [
+            DummyBrick(width: .Ratio(ratio: 1/2), height: .Fixed(size: 200)),
+            DummyBrick(width: .Ratio(ratio: 1/2), height: .Fixed(size: 100))
+            ], alignRowHeights: true)
+        collectionView.setSection(section)
+        collectionView.layoutSubviews()
 
-
-        let expectedResult = [
-            0 : [
-                CGRect(x: 0, y: 0, width: 160, height: 200),
-                CGRect(x: 160, y: 0, width: 160, height: 200),
-            ]
-        ]
-
-        let attributes = layout.layoutAttributesForElementsInRect(collectionViewFrame)
-        XCTAssertNotNil(attributes)
-        XCTAssertTrue(verifyAttributesToExpectedResult(attributes!, expectedResult: expectedResult))
+        let cell1 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 1))
+        XCTAssertEqual(cell1?.frame, CGRect(x: 0, y: 0, width: 160, height: 200))
+        let cell2 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 1, inSection: 1))
+        XCTAssertEqual(cell2?.frame, CGRect(x: 160, y: 0, width: 160, height: 200))
     }
 
     func testAlignRowHeightsMultipleRows() {
-        collectionView.layout.alignRowHeights = true
+        collectionView.registerBrickClass(DummyBrick.self)
 
-        let half = CGFloat(1.0/2.0)
-        let fourth = CGFloat(1.0/4.0)
-        setDataSources(SectionsCollectionViewDataSource(sections: [8]), brickLayoutDataSource: SectionsLayoutDataSource(widthRatios: [[half, half, fourth, fourth, fourth, fourth, fourth]], heights: [[100, 200, 100, 200, 100, 150, 100, 200]], types: [[.Brick, .Brick, .Brick, .Brick, .Brick, .Brick]]))
+        let section = BrickSection(bricks: [
+            DummyBrick(width: .Ratio(ratio: 1/2), height: .Fixed(size: 100)),
+            DummyBrick(width: .Ratio(ratio: 1/2), height: .Fixed(size: 200)),
+            DummyBrick(width: .Ratio(ratio: 1/4), height: .Fixed(size: 100)),
+            DummyBrick(width: .Ratio(ratio: 1/4), height: .Fixed(size: 200)),
+            DummyBrick(width: .Ratio(ratio: 1/4), height: .Fixed(size: 100)),
+            DummyBrick(width: .Ratio(ratio: 1/4), height: .Fixed(size: 150)),
+            DummyBrick(width: .Ratio(ratio: 1/4), height: .Fixed(size: 100)),
+            DummyBrick(width: .Ratio(ratio: 1/4), height: .Fixed(size: 200)),
+            ], alignRowHeights: true)
+        collectionView.setSection(section)
+        collectionView.layoutSubviews()
 
-
-        let layoutFourth = CGFloat(320.0/4.0)
-        let expectedResult = [
-            0 : [
-                CGRect(x: 0, y: 0, width: 160, height: 200),
-                CGRect(x: 160, y: 0, width: 160, height: 200),
-                CGRect(x: 0, y: 200, width: layoutFourth, height: 200),
-                CGRect(x: layoutFourth, y: 200, width: layoutFourth, height: 200),
-                CGRect(x: 2 * layoutFourth, y: 200, width: layoutFourth, height: 200),
-                CGRect(x: 3 * layoutFourth, y: 200, width: layoutFourth, height: 200),
-                CGRect(x: 0, y: 400, width: layoutFourth, height: 200),
-                CGRect(x: layoutFourth, y: 400, width: layoutFourth, height: 200),
-            ]
-        ]
-
-        let attributes = layout.layoutAttributesForElementsInRect(collectionViewFrame)
-        XCTAssertNotNil(attributes)
-        XCTAssertTrue(verifyAttributesToExpectedResult(attributes!, expectedResult: expectedResult))
-    }
-
-    func testAlignRowHeightsNoBricks() {
-        collectionView.layout.alignRowHeights = true
-
-        let half = CGFloat(1.0/2.0)
-        setDataSources(SectionsCollectionViewDataSource(sections: [0]), brickLayoutDataSource: SectionsLayoutDataSource(widthRatios: [[half]], heights: [[100]], types: [[.Brick]]))
-
-
-        let attributes = layout.layoutAttributesForElementsInRect(collectionViewFrame)
-        XCTAssertNotNil(attributes)
-        XCTAssertTrue(verifyAttributesToExpectedResult(attributes!, expectedResult: [:]))
+        let cell1 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 1))
+        XCTAssertEqual(cell1?.frame, CGRect(x: 0, y: 0, width: 160, height: 200))
+        let cell2 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 1, inSection: 1))
+        XCTAssertEqual(cell2?.frame, CGRect(x: 160, y: 0, width: 160, height: 200))
+        let cell3 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 2, inSection: 1))
+        XCTAssertEqual(cell3?.frame, CGRect(x: 0, y: 200, width: 80, height: 200))
+        let cell4 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 3, inSection: 1))
+        XCTAssertEqual(cell4?.frame, CGRect(x: 80, y: 200, width: 80, height: 200))
+        let cell5 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 4, inSection: 1))
+        XCTAssertEqual(cell5?.frame, CGRect(x: 160, y: 200, width: 80, height: 200))
+        let cell6 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 5, inSection: 1))
+        XCTAssertEqual(cell6?.frame, CGRect(x: 240, y: 200, width: 80, height: 200))
+        let cell7 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 6, inSection: 1))
+        XCTAssertEqual(cell7?.frame, CGRect(x: 0, y: 400, width: 80, height: 200))
+        let cell8 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 7, inSection: 1))
+        XCTAssertEqual(cell8?.frame, CGRect(x: 80, y: 400, width: 80, height: 200))
     }
 
 }

--- a/Tests/Layout/BrickInvalidationContextTests.swift
+++ b/Tests/Layout/BrickInvalidationContextTests.swift
@@ -912,12 +912,11 @@ class BrickInvalidationContextTests: XCTestCase {
 
     func testThatInvalidateWithAlignRowHeightsReportsCorrectly() {
         brickViewController.brickCollectionView.registerBrickClass(DummyBrick.self)
-        brickViewController.brickCollectionView.layout.alignRowHeights = true
 
         let section = BrickSection("Test Section", bricks: [
             DummyBrick("Brick 1", width: .Ratio(ratio: 1/2), height: .Fixed(size: 50)),
             DummyBrick("Brick 2", width: .Ratio(ratio: 1/2), height: .Fixed(size: 50)),
-            ])
+            ], alignRowHeights: true)
 
         brickViewController.setSection(section)
         brickViewController.collectionView!.layoutSubviews()

--- a/Tests/Layout/LazyLoadingTests.swift
+++ b/Tests/Layout/LazyLoadingTests.swift
@@ -138,8 +138,7 @@ class LazyLoadingTests: XCTestCase {
     func testThatAlignRowHeightsWorksProperly() {
         setupSection()
         brickView.section.inset = 10
-
-        flowLayout.alignRowHeights = true
+        brickView.section.alignRowHeights = true
 
         let attributes = brickView.collectionViewLayout.layoutAttributesForElementsInRect(CGRect(x: 0, y: 0, width: 320, height: 500))?.sort({$0.0.indexPath.item < $0.1.indexPath.item})
         let lastAttributes = attributes?.last

--- a/Tests/Utils/DataSources.swift
+++ b/Tests/Utils/DataSources.swift
@@ -185,7 +185,10 @@ class FixedBrickLayoutSectionDataSource: NSObject, BrickLayoutSectionDataSource 
         return downStreamIndexPaths
     }
 
-    var alignRowHeights: Bool = false
+    func isAlignRowHeights(in section: BrickLayoutSection) -> Bool {
+        return false
+    }
+
     var scrollDirection: UICollectionViewScrollDirection = .Vertical
 }
 
@@ -232,6 +235,9 @@ class FixedBrickLayoutDataSource: NSObject, BrickLayoutDataSource {
         return ""
     }
 
+    func brickLayout(layout: BrickLayout, isAlignRowHeightsForSection section: Int) -> Bool {
+        return false
+    }
 }
 
 class FixedSpotlightLayoutBehaviorDataSource: SpotlightLayoutBehaviorDataSource {

--- a/Tests/ViewControllers/BrickCollectionViewTests.swift
+++ b/Tests/ViewControllers/BrickCollectionViewTests.swift
@@ -621,7 +621,7 @@ class BrickCollectionViewTests: XCTestCase {
         cell2 = brickView.cellForItemAtIndexPath(NSIndexPath(forItem: 1, inSection: 2))
         XCTAssertEqual(cell2?.frame, CGRect(x: 60, y: 10, width: 410, height: 25))
     }
-
+    
     func testThatDescriptionIsCorrect() {
         XCTAssertTrue(self.brickView.description.hasSuffix("CollectionBrick: false"))
     }


### PR DESCRIPTION
The alignRowHeights property is now set per BrickSection instead of on the whole BrickLayout

Fixes #41