### PR TITLE
InvalidateRepeatCounts + identifiers

### DIFF
--- a/Source/Layout/BrickLayoutSection.swift
+++ b/Source/Layout/BrickLayoutSection.swift
@@ -149,6 +149,7 @@ internal class BrickLayoutSection {
 
         if difference > 0 {
             self.numberOfItems = numberOfItems
+            updateAttributeIdentifiers()
             createOrUpdateCells(from: attributes.count, invalidate: false, updatedAttributes: addedAttributes)
         } else {
             self.numberOfItems = numberOfItems
@@ -159,7 +160,14 @@ internal class BrickLayoutSection {
                 
                 attributes.removeValueForKey(lastIndex)
             }
+            updateAttributeIdentifiers()
             createOrUpdateCells(from: attributes.count, invalidate: true, updatedAttributes: nil)
+        }
+    }
+
+    func updateAttributeIdentifiers() {
+        for (index, attribute) in attributes {
+            attribute.identifier = _dataSource.identifier(for: index, in: self)
         }
     }
 
@@ -636,6 +644,7 @@ internal class BrickLayoutSection {
             oldFrame = nil
             oldOriginalFrame = nil
         }
+        brickAttributes.identifier = dataSource.identifier(for: indexPath.item, in: self)
 
         let height: CGFloat
 
@@ -684,7 +693,6 @@ internal class BrickLayoutSection {
     func createAttribute(at indexPath: NSIndexPath, with dataSource: BrickLayoutSectionDataSource) -> BrickLayoutAttributes {
         let brickAttributes = BrickLayoutAttributes(forCellWithIndexPath: indexPath)
 
-        brickAttributes.identifier = dataSource.identifier(for: indexPath.item, in: self)
         attributes[indexPath.item] = brickAttributes
         brickAttributes.isEstimateSize = dataSource.isEstimate(for: brickAttributes, in: self)
         return brickAttributes

--- a/Tests/Interactive/InteractiveTests.swift
+++ b/Tests/Interactive/InteractiveTests.swift
@@ -594,5 +594,28 @@ class InteractiveTests: XCTestCase {
 
         waitForExpectationsWithTimeout(5, handler: nil)
     }
+
+    func testThatInvalidateRepeatCountsSetCorrectIdentifiers() {
+        let section = BrickSection(bricks: [
+            DummyBrick("Brick1", height: .Fixed(size: 50)),
+            DummyBrick("Brick2", height: .Fixed(size: 50))
+            ])
+        let repeatCount = FixedRepeatCountDataSource(repeatCountHash: ["Brick1": 1])
+        section.repeatCountDataSource = repeatCount
+        brickView.setupSectionAndLayout(section)
+
+        repeatCount.repeatCountHash = ["Brick1": 2]
+        let expecation = expectationWithDescription("Invalidate Repeat Counts")
+
+        brickView.invalidateRepeatCounts(reloadAllSections: false) { (completed, insertedIndexPaths, deletedIndexPaths) in
+            expecation.fulfill()
+        }
+
+
+        waitForExpectationsWithTimeout(5, handler: nil)
+
+        let attributes = brickView.layout.layoutAttributesForItemAtIndexPath(NSIndexPath(forItem: 1, inSection: 1)) as? BrickLayoutAttributes
+        XCTAssertEqual(attributes?.identifier, "Brick1")
+    }
     
 }


### PR DESCRIPTION
 InvalidateRepeatCounts now ensures the identifiers of the BrickAttributes to be correct

Fixes #50