### PR TITLE
GenericBrick

### DIFF
--- a/BrickKit.xcodeproj/project.pbxproj
+++ b/BrickKit.xcodeproj/project.pbxproj
@@ -137,6 +137,10 @@
 		932365731DF4FE1F00BE5183 /* BrickAlignmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 932365711DF4FE1F00BE5183 /* BrickAlignmentTests.swift */; };
 		9328EEA61DC19ACE007F2562 /* LazyLoadingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9328EEA51DC19ACE007F2562 /* LazyLoadingTests.swift */; };
 		9328EEA71DC19ACE007F2562 /* LazyLoadingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9328EEA51DC19ACE007F2562 /* LazyLoadingTests.swift */; };
+		9333538A1E368903003CEC85 /* GenericBrick.swift in Sources */ = {isa = PBXBuildFile; fileRef = 933353891E368903003CEC85 /* GenericBrick.swift */; };
+		9333538B1E368903003CEC85 /* GenericBrick.swift in Sources */ = {isa = PBXBuildFile; fileRef = 933353891E368903003CEC85 /* GenericBrick.swift */; };
+		9333538E1E36A37F003CEC85 /* GenericBrickTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9333538D1E36A37F003CEC85 /* GenericBrickTests.swift */; };
+		9333538F1E36A37F003CEC85 /* GenericBrickTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9333538D1E36A37F003CEC85 /* GenericBrickTests.swift */; };
 		933FF95E1DC1207900E0B80E /* Swizzle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 933FF95D1DC1207900E0B80E /* Swizzle.swift */; };
 		933FF95F1DC1207900E0B80E /* Swizzle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 933FF95D1DC1207900E0B80E /* Swizzle.swift */; };
 		9350F0D61DA82A430051235F /* CollectionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9350F0D51DA82A430051235F /* CollectionInfo.swift */; };
@@ -293,6 +297,8 @@
 		9323656E1DF4FD4900BE5183 /* BrickAlignment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BrickAlignment.swift; sourceTree = "<group>"; };
 		932365711DF4FE1F00BE5183 /* BrickAlignmentTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BrickAlignmentTests.swift; sourceTree = "<group>"; };
 		9328EEA51DC19ACE007F2562 /* LazyLoadingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LazyLoadingTests.swift; sourceTree = "<group>"; };
+		933353891E368903003CEC85 /* GenericBrick.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GenericBrick.swift; path = Generic/GenericBrick.swift; sourceTree = "<group>"; };
+		9333538D1E36A37F003CEC85 /* GenericBrickTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GenericBrickTests.swift; sourceTree = "<group>"; };
 		933FF95D1DC1207900E0B80E /* Swizzle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Swizzle.swift; sourceTree = "<group>"; };
 		9350F0D51DA82A430051235F /* CollectionInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionInfo.swift; sourceTree = "<group>"; };
 		935D48D51DB806990091AA39 /* CustomBrickCollectionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomBrickCollectionView.swift; sourceTree = "<group>"; };
@@ -571,6 +577,14 @@
 			path = tvOS;
 			sourceTree = "<group>";
 		};
+		9333538C1E368908003CEC85 /* Generic */ = {
+			isa = PBXGroup;
+			children = (
+				933353891E368903003CEC85 /* GenericBrick.swift */,
+			);
+			name = Generic;
+			sourceTree = "<group>";
+		};
 		93739B951DA4548F00DD4B81 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
@@ -671,6 +685,7 @@
 		93D9EBBF1DA4057000D8C87A /* Bricks */ = {
 			isa = PBXGroup;
 			children = (
+				9333538C1E368908003CEC85 /* Generic */,
 				93739BB31DA454AB00DD4B81 /* Button */,
 				93739BAD1DA454AB00DD4B81 /* Collection */,
 				93739BB11DA454AB00DD4B81 /* Image */,
@@ -779,6 +794,7 @@
 				93D9EC271DA4057900D8C87A /* LabelBrickTests.swift */,
 				93902D3A1DA4728C00BC3BA1 /* ImageBrickTests.swift */,
 				9303A6D41DA6E00100502803 /* ButtonBrickTests.swift */,
+				9333538D1E36A37F003CEC85 /* GenericBrickTests.swift */,
 			);
 			path = Bricks;
 			sourceTree = "<group>";
@@ -1106,6 +1122,7 @@
 				4E9A25371DABEB8D00D7EA99 /* BrickModels.swift in Sources */,
 				4E9A25321DABEB8800D7EA99 /* BrickLayoutInvalidationContext.swift in Sources */,
 				4E9A251E1DABEB6000D7EA99 /* CoverFlowLayoutBehavior.swift in Sources */,
+				9333538B1E368903003CEC85 /* GenericBrick.swift in Sources */,
 				4E9A252B1DABEB6F00D7EA99 /* ImageBrick.swift in Sources */,
 				4E9A253A1DABEB8D00D7EA99 /* CollectionInfo.swift in Sources */,
 				4E9A252E1DABEB8200D7EA99 /* BrickSectionCell.swift in Sources */,
@@ -1156,6 +1173,7 @@
 				4E9A25571DABECF500D7EA99 /* BrickFlowLayoutSectionTests.swift in Sources */,
 				4E9A255F1DABECFB00D7EA99 /* BrickModelsTests.swift in Sources */,
 				4E9A255A1DABECF500D7EA99 /* BrickInvalidationContextTests.swift in Sources */,
+				9333538F1E36A37F003CEC85 /* GenericBrickTests.swift in Sources */,
 				4E9A25E61DAC2AF400D7EA99 /* BaseBrickCellTests.swift in Sources */,
 				4E9A25641DABECFF00D7EA99 /* CollectionViewDataSource.swift in Sources */,
 				4E9A254E1DABECE300D7EA99 /* CollectionBrickTests.swift in Sources */,
@@ -1213,6 +1231,7 @@
 				93D9EBF41DA4057000D8C87A /* StickyFooterLayoutBehavior.swift in Sources */,
 				93D9EBF11DA4057000D8C87A /* SetZIndexLayoutBehavior.swift in Sources */,
 				93D9EC0D1DA4057000D8C87A /* BrickCollectionViewDataSource.swift in Sources */,
+				9333538A1E368903003CEC85 /* GenericBrick.swift in Sources */,
 				93D9EC081DA4057000D8C87A /* BrickFlowLayout.swift in Sources */,
 				93D9EC0B1DA4057000D8C87A /* BrickLayoutSection.swift in Sources */,
 				93D9EBEA1DA4057000D8C87A /* CoverFlowLayoutBehavior.swift in Sources */,
@@ -1237,6 +1256,7 @@
 				93D9EC721DA4057900D8C87A /* BrickFlowLayoutBaseTests.swift in Sources */,
 				9372C5081DA4073D007D7EA1 /* FatalErrorTests.swift in Sources */,
 				93D9EC621DA4057900D8C87A /* AsynchronousResizableBrick.swift in Sources */,
+				9333538E1E36A37F003CEC85 /* GenericBrickTests.swift in Sources */,
 				93D9EC591DA4057900D8C87A /* MinimumStickyLayoutBehaviorTests.swift in Sources */,
 				93D9EC7F1DA4057900D8C87A /* BrickExtensionsTests.swift in Sources */,
 				93D9EC651DA4057900D8C87A /* DummyBrick.swift in Sources */,

--- a/Source/Bricks/Generic/GenericBrick.swift
+++ b/Source/Bricks/Generic/GenericBrick.swift
@@ -22,11 +22,10 @@ public class GenericBrick<T: UIView>: Brick, ViewGenerator {
         super.init(identifier, size: size, backgroundColor: backgroundColor, backgroundView: backgroundView)
     }
 
-    /// Class variable: Default nib name to be used for this brick's cell
-    // If not overriden, it uses the same as the Brick class
-    public override class var nibName: String {
-        let generic = NSStringFromClass(T.self).componentsSeparatedByString(".").last!
-        return "Generic[\(generic)]"
+    // Override this property to ensure that the identifier is correctly set (as it uses generics, `NSStringForClass` isn't reliable)
+    public override class var internalIdentifier: String {
+        let generic = NSStringFromClass(T.self)
+        return "GenericBrick[\(generic)]"
     }
 
     public class override var cellClass: UICollectionViewCell.Type? {
@@ -58,10 +57,10 @@ public class GenericBrickCell: BrickCell {
 
             self.contentView.addSubview(genericContentView)
 
-            let topSpaceConstraint = NSLayoutConstraint(item: genericContentView, attribute: .Top, relatedBy: .Equal, toItem: self.contentView, attribute: .Top, multiplier: 1, constant: edgeInsets.top)
-            let bottomSpaceConstraint = NSLayoutConstraint(item: self.contentView, attribute: .Bottom, relatedBy: .Equal, toItem: genericContentView, attribute: .Bottom, multiplier: 1, constant: edgeInsets.bottom)
-            let leftSpaceConstraint = NSLayoutConstraint(item: genericContentView, attribute: .Left, relatedBy: .Equal, toItem: self.contentView, attribute: .Left, multiplier: 1, constant: edgeInsets.left)
-            let rightSpaceConstraint = NSLayoutConstraint(item: self.contentView, attribute: .Right, relatedBy: .Equal, toItem: genericContentView, attribute: .Right, multiplier: 1, constant: edgeInsets.right)
+            let topSpaceConstraint = genericContentView.topAnchor.constraintEqualToAnchor(self.contentView.topAnchor, constant: edgeInsets.top)
+            let bottomSpaceConstraint = self.contentView.bottomAnchor.constraintEqualToAnchor(genericContentView.bottomAnchor, constant: edgeInsets.bottom)
+            let leftSpaceConstraint = genericContentView.leftAnchor.constraintEqualToAnchor(self.contentView.leftAnchor, constant: edgeInsets.left)
+            let rightSpaceConstraint = self.contentView.rightAnchor.constraintEqualToAnchor(genericContentView.rightAnchor, constant: edgeInsets.right)
 
             self.contentView.addConstraints([topSpaceConstraint, bottomSpaceConstraint, leftSpaceConstraint, rightSpaceConstraint])
             self.contentView.setNeedsUpdateConstraints()

--- a/Source/Bricks/Generic/GenericBrick.swift
+++ b/Source/Bricks/Generic/GenericBrick.swift
@@ -1,0 +1,89 @@
+//
+//  GenericBrick.swift
+//  BrickKit
+//
+//  Created by Ruben Cagnie on 1/23/17.
+//  Copyright © 2017 Wayfair. All rights reserved.
+//
+
+import UIKit
+
+protocol ViewGenerator {
+    func generateView(frame: CGRect, in cell: GenericBrickCell) -> UIView
+}
+
+public class GenericBrick<T: UIView>: Brick, ViewGenerator {
+    public typealias ConfigureView = (view: T, cell: GenericBrickCell) -> Void
+
+    public var configureView: ConfigureView
+
+    public init(_ identifier: String = "", size: BrickSize, backgroundColor: UIColor = .clearColor(), backgroundView: UIView? = nil, configureView: ConfigureView) {
+        self.configureView = configureView
+        super.init(identifier, size: size, backgroundColor: backgroundColor, backgroundView: backgroundView)
+    }
+
+    /// Class variable: Default nib name to be used for this brick's cell
+    // If not overriden, it uses the same as the Brick class
+    public override class var nibName: String {
+        let generic = NSStringFromClass(T.self).componentsSeparatedByString(".").last!
+        return "Generic[\(generic)]"
+    }
+
+    public class override var cellClass: UICollectionViewCell.Type? {
+        return GenericBrickCell.self
+    }
+
+    public func generateView(frame: CGRect, in cell: GenericBrickCell) -> UIView {
+        let view = T(frame: frame)
+
+        self.configureView(view: view, cell: cell)
+
+        return view
+    }
+
+}
+
+public class GenericBrickCell: BrickCell {
+
+    var genericContentView: UIView?
+
+    public override func updateContent() {
+        super.updateContent()
+
+        clearContentViewAndConstraints()
+
+        if let generic = self._brick as? ViewGenerator {
+            let genericContentView = generic.generateView(self.frame, in: self)
+            genericContentView.translatesAutoresizingMaskIntoConstraints = false
+
+            self.contentView.addSubview(genericContentView)
+
+            let topSpaceConstraint = NSLayoutConstraint(item: genericContentView, attribute: .Top, relatedBy: .Equal, toItem: self.contentView, attribute: .Top, multiplier: 1, constant: edgeInsets.top)
+            let bottomSpaceConstraint = NSLayoutConstraint(item: self.contentView, attribute: .Bottom, relatedBy: .Equal, toItem: genericContentView, attribute: .Bottom, multiplier: 1, constant: edgeInsets.bottom)
+            let leftSpaceConstraint = NSLayoutConstraint(item: genericContentView, attribute: .Left, relatedBy: .Equal, toItem: self.contentView, attribute: .Left, multiplier: 1, constant: edgeInsets.left)
+            let rightSpaceConstraint = NSLayoutConstraint(item: self.contentView, attribute: .Right, relatedBy: .Equal, toItem: genericContentView, attribute: .Right, multiplier: 1, constant: edgeInsets.right)
+
+            self.contentView.addConstraints([topSpaceConstraint, bottomSpaceConstraint, leftSpaceConstraint, rightSpaceConstraint])
+            self.contentView.setNeedsUpdateConstraints()
+
+            // Assign to instance
+            self.genericContentView = genericContentView
+            self.topSpaceConstraint = topSpaceConstraint
+            self.bottomSpaceConstraint = bottomSpaceConstraint
+            self.leftSpaceConstraint = leftSpaceConstraint
+            self.rightSpaceConstraint = rightSpaceConstraint
+        }
+
+    }
+
+    private func clearContentViewAndConstraints() {
+        genericContentView?.removeFromSuperview()
+        genericContentView = nil
+
+        topSpaceConstraint = nil
+        bottomSpaceConstraint = nil
+        leftSpaceConstraint = nil
+        rightSpaceConstraint = nil
+    }
+
+}

--- a/Source/Bricks/Generic/GenericBrick.swift
+++ b/Source/Bricks/Generic/GenericBrick.swift
@@ -17,6 +17,10 @@ public class GenericBrick<T: UIView>: Brick, ViewGenerator {
 
     public var configureView: ConfigureView
 
+    public convenience init(_ identifier: String = "", width: BrickDimension = .Ratio(ratio: 1), height: BrickDimension = .Auto(estimate: .Fixed(size: 50)), backgroundColor: UIColor = UIColor.clearColor(), backgroundView: UIView? = nil, configureView: ConfigureView) {
+        self.init(identifier, size: BrickSize(width: width, height: height), backgroundColor: backgroundColor, backgroundView: backgroundView, configureView: configureView)
+    }
+
     public init(_ identifier: String = "", size: BrickSize, backgroundColor: UIColor = .clearColor(), backgroundView: UIView? = nil, configureView: ConfigureView) {
         self.configureView = configureView
         super.init(identifier, size: size, backgroundColor: backgroundColor, backgroundView: backgroundView)

--- a/Source/Cells/BrickCell.swift
+++ b/Source/Cells/BrickCell.swift
@@ -110,7 +110,7 @@ extension BaseBrickCell {
 
 public class BrickCell: BaseBrickCell {
 
-    private var _brick: Brick! {
+    internal var _brick: Brick! {
         didSet {
             self.accessibilityIdentifier = _brick.accessibilityIdentifier
             self.accessibilityLabel = _brick.accessibilityLabel

--- a/Source/Models/BrickModels.swift
+++ b/Source/Models/BrickModels.swift
@@ -103,6 +103,12 @@ public class Brick: CustomStringConvertible {
         return NSStringFromClass(self).componentsSeparatedByString(".").last!
     }
 
+    // The internal identifier to use for this brick
+    // This is used when storing the registered brick
+    public class var internalIdentifier: String {
+        return NSStringFromClass(self)
+    }
+
     /// Class variable: If not nil, this class will be used to load this brick's cell
     public class var cellClass: UICollectionViewCell.Type? {
         return nil

--- a/Source/ViewControllers/BrickCollectionView.swift
+++ b/Source/ViewControllers/BrickCollectionView.swift
@@ -94,10 +94,7 @@ public class BrickCollectionView: UICollectionView {
         registerClass(BrickSectionCell.self, forCellWithReuseIdentifier: BrickSection.nibName)
     }
 
-}
-
 // MARK: - Setting up the models
-extension BrickCollectionView {
 
     /// Sets the section for the BrickCollectionView
     ///
@@ -125,18 +122,18 @@ extension BrickCollectionView {
     /// - parameter brickClass: The brick class to register
     /// - parameter nib: The nib to register. This only needs to be set if the nib is different then the default
     public func registerBrickClass(brickClass: Brick.Type, nib: UINib? = nil) {
-        let nibName = brickClass.nibName
+        let identifier = brickClass.internalIdentifier
         let cellIdentifier: String
 
         if let cellClass = brickClass.cellClass {
-            cellIdentifier = nibName
+            cellIdentifier = identifier
             self.registerClass(cellClass, forCellWithReuseIdentifier: cellIdentifier)
-        } else if nib != nil || brickClass.bundle.pathForResource(nibName, ofType: "nib") != nil {
+        } else if nib != nil || brickClass.bundle.pathForResource(brickClass.nibName, ofType: "nib") != nil {
             let brickNib: UINib
             if let defaultNib = nib {
                 brickNib = defaultNib
             } else {
-                brickNib = UINib(nibName: nibName, bundle: brickClass.bundle)
+                brickNib = UINib(nibName: brickClass.nibName, bundle: brickClass.bundle)
             }
             cellIdentifier = String(brickNib.hashValue)
             self.registerNib(brickNib, forCellWithReuseIdentifier: cellIdentifier)
@@ -148,7 +145,7 @@ extension BrickCollectionView {
             print("calling `registerBrickClass` in `configure(for cell: CollectionBrickCell)` is deprecated. Use `registerBricks(for cell: CollectionBrickCell)` or `CollectionBrickCell(brickTypes: [Brick.Type])`. This will be a fatalError in a future release")
         }
         
-        registeredBricks[nibName] = cellIdentifier
+        registeredBricks[identifier] = cellIdentifier
     }
 
     /// Register a brick class.
@@ -193,7 +190,7 @@ extension BrickCollectionView {
             identifier = BrickSection.nibName
         } else if let brickIdentifier = registeredBricks[CustomNibPrefix + brick.identifier] {
             identifier = brickIdentifier
-        } else if let brickIdentifier = registeredBricks[brick.nibName] {
+        } else if let brickIdentifier = registeredBricks[brick.dynamicType.internalIdentifier] {
             identifier = brickIdentifier
         } else {
             fatalError("No Nib Found for \(brick)")
@@ -201,10 +198,7 @@ extension BrickCollectionView {
         return identifier
     }
 
-}
-
 // MARK: - Invalidation
-extension BrickCollectionView {
 
     /// Invalidate the layout properties and recalculate sizes
     ///
@@ -240,10 +234,7 @@ extension BrickCollectionView {
         }
     }
     
-}
-
 // MARK: - Reloading
-extension BrickCollectionView {
 
     /// Reload bricks in a collectionbrick
     ///

--- a/Source/ViewControllers/BrickViewController.swift
+++ b/Source/ViewControllers/BrickViewController.swift
@@ -78,11 +78,7 @@ public class BrickViewController: UIViewController, UICollectionViewDelegate {
         }
     }
 
-}
-
 // MARK: - Convenience methods
-extension BrickViewController {
-
     public func setSection(section: BrickSection) {
         brickCollectionView.setSection(section)
     }

--- a/Tests/Bricks/GenericBrickTests.swift
+++ b/Tests/Bricks/GenericBrickTests.swift
@@ -1,0 +1,108 @@
+//
+//  GenericBrickTests.swift
+//  BrickKit
+//
+//  Created by Ruben Cagnie on 1/23/17.
+//  Copyright © 2017 Wayfair. All rights reserved.
+//
+
+import XCTest
+@testable import BrickKit
+
+private let GenericLabelBrickIdentifier = "GenericLabelBrick"
+private let GenericButtonBrickIdentifier = "GenericButtonBrick"
+
+class GenericBrickTests: XCTestCase {
+    var brickCollectionView: BrickCollectionView!
+
+    override func setUp() {
+        super.setUp()
+
+        continueAfterFailure = false
+        brickCollectionView = BrickCollectionView(frame: CGRect(x: 0, y: 0, width: 320, height: 480))
+    }
+
+    private func firstCellForIdentifier<T: BrickCell>(identifier: String) -> T? {
+        guard let indexPath = brickCollectionView.indexPathsForBricksWithIdentifier(identifier).first else {
+            return nil
+        }
+        return brickCollectionView.cellForItemAtIndexPath(indexPath) as? T
+    }
+
+    func testGenericBrickWithLabel() {
+        brickCollectionView.setupSingleBrickAndLayout(GenericBrick<UILabel>(GenericLabelBrickIdentifier, size: BrickSize(width: .Ratio(ratio: 1), height: .Fixed(size: 50))) { label, view in
+            })
+
+        let cell: GenericBrickCell? = firstCellForIdentifier(GenericLabelBrickIdentifier)
+
+        XCTAssertNotNil(cell)
+
+        XCTAssertTrue(cell!.genericContentView is UILabel)
+        XCTAssertTrue(cell!.contentView.subviews.first is UILabel)
+    }
+
+    func testGenericBrickWithButton() {
+        brickCollectionView.setupSingleBrickAndLayout(GenericBrick<UIButton>(GenericButtonBrickIdentifier, size: BrickSize(width: .Ratio(ratio: 1), height: .Fixed(size: 50))) { button, view in
+            })
+
+        let cell: GenericBrickCell? = firstCellForIdentifier(GenericButtonBrickIdentifier)
+
+        XCTAssertNotNil(cell)
+
+        XCTAssertTrue(cell!.genericContentView is UIButton)
+        XCTAssertTrue(cell!.contentView.subviews.first is UIButton)
+    }
+
+    func testThatLabelIsInitialized() {
+        let text = "Hello World"
+        brickCollectionView.setupSingleBrickAndLayout(GenericBrick<UILabel>(GenericLabelBrickIdentifier, size: BrickSize(width: .Ratio(ratio: 1), height: .Fixed(size: 50))) { label, view in
+            label.text = text
+            })
+
+        let cell: GenericBrickCell? = firstCellForIdentifier(GenericLabelBrickIdentifier)
+
+        let label = cell!.genericContentView as! UILabel
+        XCTAssertEqual(label.text, text)
+        XCTAssertEqual(label.frame, CGRect(x: 0, y: 0, width: 320, height: 50))
+    }
+
+    func testThatLabelHasEdgeInsets() {
+        let genericBrick = GenericBrick<UILabel>(GenericLabelBrickIdentifier, size: BrickSize(width: .Ratio(ratio: 1), height: .Fixed(size: 50))) { label, view in
+            view.edgeInsets = UIEdgeInsets(top: 5, left: 10, bottom: 15, right: 20)
+        }
+        brickCollectionView.setupSingleBrickAndLayout(genericBrick)
+
+        let cell: GenericBrickCell? = firstCellForIdentifier(GenericLabelBrickIdentifier)
+        cell?.layoutIfNeeded()
+
+        let label = cell!.genericContentView as! UILabel
+        XCTAssertEqual(cell?.contentView.frame, CGRect(x: 0, y: 0, width: 320, height: 50))
+        XCTAssertEqual(label.frame, CGRect(x: 10, y: 5, width: 290, height: 30))
+    }
+
+    func testThatRepeatCountWorks() {
+        let genericBrick = GenericBrick<UILabel>(GenericLabelBrickIdentifier, size: BrickSize(width: .Ratio(ratio: 1), height: .Fixed(size: 50))) { label, cell in
+            label.text = "LABEL " + String(cell.index)
+        }
+
+        let section = BrickSection(bricks: [genericBrick])
+        let repeatCount = FixedRepeatCountDataSource(repeatCountHash: [GenericLabelBrickIdentifier: 5])
+        section.repeatCountDataSource = repeatCount
+        brickCollectionView.setupSectionAndLayout(section)
+
+        let indexPaths = brickCollectionView.indexPathsForBricksWithIdentifier(GenericLabelBrickIdentifier)
+        XCTAssertEqual(indexPaths.count, 5)
+
+        let label0 = (brickCollectionView.cellForItemAtIndexPath(indexPaths[0]) as! GenericBrickCell).genericContentView as! UILabel
+        XCTAssertEqual(label0.text, "LABEL 0")
+        let label1 = (brickCollectionView.cellForItemAtIndexPath(indexPaths[1]) as! GenericBrickCell).genericContentView as! UILabel
+        XCTAssertEqual(label1.text, "LABEL 1")
+        let label2 = (brickCollectionView.cellForItemAtIndexPath(indexPaths[2]) as! GenericBrickCell).genericContentView as! UILabel
+        XCTAssertEqual(label2.text, "LABEL 2")
+        let label3 = (brickCollectionView.cellForItemAtIndexPath(indexPaths[3]) as! GenericBrickCell).genericContentView as! UILabel
+        XCTAssertEqual(label3.text, "LABEL 3")
+        let label4 = (brickCollectionView.cellForItemAtIndexPath(indexPaths[4]) as! GenericBrickCell).genericContentView as! UILabel
+        XCTAssertEqual(label4.text, "LABEL 4")
+    }
+
+}

--- a/Tests/Bricks/GenericBrickTests.swift
+++ b/Tests/Bricks/GenericBrickTests.swift
@@ -30,7 +30,7 @@ class GenericBrickTests: XCTestCase {
     }
 
     func testGenericBrickWithLabel() {
-        brickCollectionView.setupSingleBrickAndLayout(GenericBrick<UILabel>(GenericLabelBrickIdentifier, size: BrickSize(width: .Ratio(ratio: 1), height: .Fixed(size: 50))) { label, view in
+        brickCollectionView.setupSingleBrickAndLayout(GenericBrick<UILabel>(GenericLabelBrickIdentifier, width: .Ratio(ratio: 1), height: .Fixed(size: 50)) { label, view in
             })
 
         let cell: GenericBrickCell? = firstCellForIdentifier(GenericLabelBrickIdentifier)

--- a/Tests/Utils/XCTests.swift
+++ b/Tests/Utils/XCTests.swift
@@ -124,12 +124,20 @@ extension XCTest {
 
 extension BrickCollectionView {
 
+    func setupSingleBrickAndLayout(brick: Brick) {
+        setupSectionAndLayout(BrickSection(bricks: [brick]))
+    }
+
     func setupSectionAndLayout(section: BrickSection) {
         self.registerBrickClass(CollectionBrick.self)
         self.registerBrickClass(DummyBrick.self)
         self.registerBrickClass(LabelBrick.self)
         self.registerBrickClass(ButtonBrick.self)
         self.registerBrickClass(ImageBrick.self)
+
+        self.registerBrickClass(GenericBrick<UILabel>.self)
+        self.registerBrickClass(GenericBrick<UIButton>.self)
+        self.registerBrickClass(GenericBrick<UIImageView>.self)
 
         self.setSection(section)
         self.layoutSubviews()


### PR DESCRIPTION
Introduction of a GenericBrick, that allows to wrap any UIView in a Brick.

This will allow a straight forward syntax:
```
GenericBrick<UILabel>(GenericLabelBrickIdentifier, size: BrickSize(...)) { label, cell in
            label.text = "LABEL " + String(cell.index)
            cell.edgeInsets = UIEdgeInsets(top: 5, left: 10, bottom: 15, right: 20)
        }
```

Fixes #64