### PR TITLE
Horizontal and Vertical BrickAlignment

### DIFF
--- a/Example/Source/Examples/Interactive/InteractiveAlignViewController.swift
+++ b/Example/Source/Examples/Interactive/InteractiveAlignViewController.swift
@@ -55,7 +55,7 @@ class InteractiveAlignViewController: BrickViewController {
 
         let section = BrickSection(bricks: [
             labelBrick,
-            ], inset: 10, edgeInsets: UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10), alignment: .Center)
+            ], inset: 10, edgeInsets: UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10), alignment: BrickAlignment(horizontal: .Center, vertical: .Top))
         section.repeatCountDataSource = self
         setSection(section)
     }

--- a/Example/Source/Examples/Simple/AlignmentBrickViewController.swift
+++ b/Example/Source/Examples/Simple/AlignmentBrickViewController.swift
@@ -9,6 +9,27 @@
 import UIKit
 import BrickKit
 
+class HorizontalSegmentedControl: SegmentHeaderBrickDataSource {
+    static let identifier = "Horizontal"
+
+    var selectedSegmentIndex: Int = 0
+
+    var titles: [String] {
+        return ["Left", "Center", "Right", "Justified"]
+    }
+    
+}
+class VerticalSegmentedControl: SegmentHeaderBrickDataSource {
+    static let identifier = "Vertical"
+
+    var selectedSegmentIndex: Int = 0
+
+    var titles: [String] {
+        return ["Top", "Center", "Bottom"]
+    }
+    
+}
+
 class AlignmentBrickViewController: BrickViewController {
 
     override class var title: String {
@@ -22,20 +43,36 @@ class AlignmentBrickViewController: BrickViewController {
     var brickSection2: BrickSection!
     var brickSection3: BrickSection!
 
-    var selectedSegmentIndex: Int = 0 {
+    var horizontalSegmentedControl = HorizontalSegmentedControl()
+    var verticalSegmentedControl = VerticalSegmentedControl()
+
+    var horizontalSelectedSegmentIndex: Int = 0 {
         didSet {
-            let alignment: BrickAlignment
-            switch selectedSegmentIndex {
-            case 1: alignment = .Center
-            case 2: alignment = .Right
-            case 3: alignment = .Justified
-            default: alignment = .Left
-            }
-            brickSection1.alignment = alignment
-            brickSection2.alignment = alignment
-            brickSection3.alignment = alignment
-            self.brickCollectionView.invalidateBricks()
         }
+    }
+
+    func updateAligments() {
+        let horizontalAlignment: BrickHorizontalAlignment
+        switch horizontalSegmentedControl.selectedSegmentIndex {
+        case 1: horizontalAlignment = .Center
+        case 2: horizontalAlignment = .Right
+        case 3: horizontalAlignment = .Justified
+        default: horizontalAlignment = .Left
+        }
+
+        let verticalAlignment: BrickVerticalAlignment
+        switch verticalSegmentedControl.selectedSegmentIndex {
+        case 1: verticalAlignment = .Center
+        case 2: verticalAlignment = .Bottom
+        default: verticalAlignment = .Top
+        }
+
+        let alignment = BrickAlignment(horizontal: horizontalAlignment, vertical: verticalAlignment)
+        brickSection1.alignment = alignment
+        brickSection2.alignment = alignment
+        brickSection3.alignment = alignment
+
+        self.brickCollectionView.invalidateBricks(false)
     }
 
     override func viewDidLoad() {
@@ -47,14 +84,14 @@ class AlignmentBrickViewController: BrickViewController {
         self.brickCollectionView.registerBrickClass(SegmentHeaderBrick.self)
 
         brickSection1 = BrickSection(backgroundColor: .brickGray1, bricks: [
-            LabelBrick(width: .Fixed(size: 60), height: .Fixed(size: 100), backgroundColor: .brickGray2, text: "BRICK", configureCellBlock: LabelBrickCell.configure),
-            LabelBrick(width: .Fixed(size: 60), height: .Fixed(size: 100), backgroundColor: .brickGray2, text: "BRICK", configureCellBlock: LabelBrickCell.configure),
-            LabelBrick(width: .Fixed(size: 60), height: .Fixed(size: 100), backgroundColor: .brickGray2, text: "BRICK", configureCellBlock: LabelBrickCell.configure),
+            LabelBrick(width: .Fixed(size: 70), height: .Fixed(size: 100), backgroundColor: .brickGray2, text: "BRICK", configureCellBlock: LabelBrickCell.configure),
+            LabelBrick(width: .Fixed(size: 70), height: .Fixed(size: 50), backgroundColor: .brickGray2, text: "BRICK", configureCellBlock: LabelBrickCell.configure),
+            LabelBrick(width: .Fixed(size: 70), height: .Fixed(size: 75), backgroundColor: .brickGray2, text: "BRICK", configureCellBlock: LabelBrickCell.configure),
             ], inset: 10)
 
         brickSection2 = BrickSection(backgroundColor: .brickGray1, bricks: [
             LabelBrick(width: .Ratio(ratio: 1/3), height: .Fixed(size: 100), backgroundColor: .brickGray2, text: "BRICK", configureCellBlock: LabelBrickCell.configure),
-            LabelBrick(width: .Ratio(ratio: 1/3), height: .Fixed(size: 100), backgroundColor: .brickGray2, text: "BRICK", configureCellBlock: LabelBrickCell.configure),
+            LabelBrick(width: .Ratio(ratio: 1/3), height: .Fixed(size: 50), backgroundColor: .brickGray2, text: "BRICK", configureCellBlock: LabelBrickCell.configure),
             ], inset: 10)
 
         brickSection3 = BrickSection(backgroundColor: .brickGray1, bricks: [
@@ -64,7 +101,14 @@ class AlignmentBrickViewController: BrickViewController {
         brickSection3.repeatCountDataSource = self
 
         let section = BrickSection(bricks: [
-            SegmentHeaderBrick(dataSource: self, delegate: self),
+            BrickSection(bricks: [
+                LabelBrick(text: "Horizontal", configureCellBlock: LabelBrickCell.configure),
+                SegmentHeaderBrick(HorizontalSegmentedControl.identifier, dataSource: horizontalSegmentedControl, delegate: self),
+                ]),
+            BrickSection(bricks: [
+                LabelBrick(text: "Vertical", configureCellBlock: LabelBrickCell.configure),
+                SegmentHeaderBrick(VerticalSegmentedControl.identifier, dataSource: verticalSegmentedControl, delegate: self),
+                ]),
             brickSection1,
             brickSection2,
             brickSection3
@@ -85,17 +129,14 @@ extension AlignmentBrickViewController: BrickRepeatCountDataSource {
     }
 }
 
-extension AlignmentBrickViewController: SegmentHeaderBrickDataSource {
-
-    var titles: [String] {
-        return ["Left", "Center", "Right", "Justified"]
-    }
-
-}
-
 extension AlignmentBrickViewController: SegmentHeaderBrickDelegate {
     func segementHeaderBrickCell(cell: SegmentHeaderBrickCell, didSelectIndex index: Int) {
-        self.selectedSegmentIndex = index
+        if cell.brick.identifier == HorizontalSegmentedControl.identifier {
+            self.horizontalSegmentedControl.selectedSegmentIndex = index
+        } else if cell.brick.identifier == VerticalSegmentedControl.identifier {
+            self.verticalSegmentedControl.selectedSegmentIndex = index
+        }
+        updateAligments()
     }
 }
 

--- a/Example/Source/Examples/Simple/SimpleRepeatFixedWidthViewController.swift
+++ b/Example/Source/Examples/Simple/SimpleRepeatFixedWidthViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import BrickKit
 
 class SimpleRepeatFixedWidthViewController: BaseRepeatBrickViewController {
 
@@ -22,7 +23,7 @@ class SimpleRepeatFixedWidthViewController: BaseRepeatBrickViewController {
 
         repeatLabel.width = .Fixed(size: 80)
         repeatLabel.height = .Auto(estimate: .Fixed(size: 38.0))
-        brickCollectionView.section.alignment = .Justified
+        brickCollectionView.section.alignment = BrickAlignment(horizontal: .Justified, vertical: .Top)
     }
 
 }

--- a/Source/Layout/BrickLayout.swift
+++ b/Source/Layout/BrickLayout.swift
@@ -108,7 +108,7 @@ extension BrickLayoutDataSource {
     }
 
     public func brickLayout(layout: BrickLayout, alignmentForSection section: Int) -> BrickAlignment {
-        return .Left
+        return BrickAlignment(horizontal: .Left, vertical: .Top)
     }
 
 }

--- a/Source/Layout/BrickLayoutSection.swift
+++ b/Source/Layout/BrickLayoutSection.swift
@@ -467,9 +467,9 @@ internal class BrickLayoutSection {
 
         let inset: CGFloat
         let numberOfInsets: CGFloat = CGFloat(rowAttributes.count-1)
-        let aligment = _dataSource.aligment(in: self)
+        let alignment = _dataSource.aligment(in: self)
 
-        switch aligment {
+        switch alignment.horizontal {
         case .Justified:
             // Distribute insets evenly
             inset = (totalSectionWidth - rowWidthWithoutInsets) / numberOfInsets
@@ -480,7 +480,7 @@ internal class BrickLayoutSection {
 
         // Get the x value of the first brick
         let startX: CGFloat
-        switch aligment {
+        switch alignment.horizontal {
         case .Center: startX = (totalSectionWidth - totalRowWidth) / 2 // Start from the middle minus the middle of the bricks total width
         case .Right: startX = totalSectionWidth - totalRowWidth // Start at the end of the section minus the total of the bricks total width
         default: startX = 0 // Start at zero
@@ -505,6 +505,15 @@ internal class BrickLayoutSection {
                 newFrame.size.height = maxHeight
             }
             newFrame.origin.x = x
+
+            let offsetY: CGFloat
+            switch _dataSource.aligment(in: self).vertical {
+            case .Top: offsetY = 0
+            case .Center: offsetY = (maxHeight / 2) - (newFrame.height / 2)
+            case .Bottom: offsetY = maxHeight - newFrame.height
+            }
+
+            newFrame.origin.y += offsetY
             if newFrame != oldFrame {
                 brickAttributes.frame = newFrame
                 updatedAttributes?(attributes: brickAttributes, oldFrame: oldFrame)

--- a/Source/Models/BrickAlignment.swift
+++ b/Source/Models/BrickAlignment.swift
@@ -6,10 +6,29 @@
 //  Copyright © 2016 Wayfair. All rights reserved.
 //
 
-/// Enum that indicates how bricks should be aligned within the same row
-public enum BrickAlignment {
+// BrickAlignment indicates how bricks are aligned horizontally and vertically
+public struct BrickAlignment {
+
+    let horizontal: BrickHorizontalAlignment
+    let vertical: BrickVerticalAlignment
+
+    public init(horizontal: BrickHorizontalAlignment, vertical: BrickVerticalAlignment) {
+        self.horizontal = horizontal
+        self.vertical = vertical
+    }
+}
+
+/// Enum that indicates how bricks should be aligned horizontally within the same row
+public enum BrickHorizontalAlignment {
     case Left
     case Right
     case Center
     case Justified
+}
+
+/// Enum that indicates how bricks should be aligned vertically within the same row
+public enum BrickVerticalAlignment {
+    case Top
+    case Bottom
+    case Center
 }

--- a/Source/Models/BrickModels.swift
+++ b/Source/Models/BrickModels.swift
@@ -156,7 +156,7 @@ public class BrickSection: Brick {
         }
     }
 
-    public init(_ identifier: String = "", width: BrickDimension = .Ratio(ratio: 1), height: BrickDimension = .Auto(estimate: .Fixed(size: 0)), backgroundColor: UIColor = .clearColor(), backgroundView: UIView? = nil, bricks: [Brick], inset: CGFloat = 0, edgeInsets: UIEdgeInsets = UIEdgeInsetsZero, alignRowHeights: Bool = false, alignment: BrickAlignment = .Left) {
+    public init(_ identifier: String = "", width: BrickDimension = .Ratio(ratio: 1), height: BrickDimension = .Auto(estimate: .Fixed(size: 0)), backgroundColor: UIColor = .clearColor(), backgroundView: UIView? = nil, bricks: [Brick], inset: CGFloat = 0, edgeInsets: UIEdgeInsets = UIEdgeInsetsZero, alignRowHeights: Bool = false, alignment: BrickAlignment = BrickAlignment(horizontal: .Left, vertical: .Top)) {
         self.bricks = bricks
         self.inset = inset
         self.edgeInsets = edgeInsets

--- a/Source/ViewControllers/BrickCollectionView+BrickLayoutDataSource.swift
+++ b/Source/ViewControllers/BrickCollectionView+BrickLayoutDataSource.swift
@@ -76,7 +76,7 @@ extension BrickCollectionView: BrickLayoutDataSource {
             let indexPath = self.section.indexPathForSection(section, in: collectionInfo),
             let brickSection = self.brick(at:indexPath) as? BrickSection
             else {
-                return .Left
+                return BrickAlignment(horizontal: .Left, vertical: .Top)
         }
         return brickSection.alignment
     }

--- a/Tests/Models/BrickAlignmentTests.swift
+++ b/Tests/Models/BrickAlignmentTests.swift
@@ -16,13 +16,10 @@ class BrickAlignmentTests: BrickFlowLayoutBaseTests {
 extension BrickAlignmentTests {
 
     func testThatLeftAlignDoesnChangeDefaultBehavior() {
-        collectionView.registerBrickClass(DummyBrick.self)
-
         let section = BrickSection(bricks: [
             DummyBrick(height: .Fixed(size: 50)),
-            ], inset: 10, edgeInsets: UIEdgeInsets(top: 5, left: 5, bottom: 5, right: 5), alignment: .Left)
-        collectionView.setSection(section)
-        collectionView.layoutSubviews()
+            ], inset: 10, edgeInsets: UIEdgeInsets(top: 5, left: 5, bottom: 5, right: 5), alignment: BrickAlignment(horizontal: .Left, vertical: .Top))
+        collectionView.setupSectionAndLayout(section)
 
         let cell1 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 1))
         XCTAssertEqual(cell1?.frame, CGRect(x: 5, y: 5, width: 310, height: 50))
@@ -31,14 +28,12 @@ extension BrickAlignmentTests {
     func testThatLeftAlignIgnoresHiddenBricks() {
         let hideBehaviorDataSource = FixedHideBehaviorDataSource(indexPaths: [NSIndexPath(forItem: 0, inSection: 1)])
         collectionView.layout.hideBehaviorDataSource = hideBehaviorDataSource
-        collectionView.registerBrickClass(DummyBrick.self)
 
         let section = BrickSection(bricks: [
             DummyBrick(height: .Fixed(size: 50)),
             DummyBrick(height: .Fixed(size: 50)),
-            ], inset: 10, edgeInsets: UIEdgeInsets(top: 5, left: 5, bottom: 5, right: 5), alignRowHeights: true, alignment: .Left)
-        collectionView.setSection(section)
-        collectionView.layoutSubviews()
+            ], inset: 10, edgeInsets: UIEdgeInsets(top: 5, left: 5, bottom: 5, right: 5), alignRowHeights: true, alignment: BrickAlignment(horizontal: .Left, vertical: .Top))
+        collectionView.setupSectionAndLayout(section)
 
         let cell1 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 1))
         XCTAssertNil(cell1)
@@ -47,15 +42,12 @@ extension BrickAlignmentTests {
     }
     
     func testThatLeftAlignmentBricks() {
-        collectionView.registerBrickClass(DummyBrick.self)
-
         let section = BrickSection(bricks: [
             DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 50)),
             DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 50)),
             DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 50)),
-            ], alignment: .Left)
-        collectionView.setSection(section)
-        collectionView.layoutSubviews()
+            ], alignment: BrickAlignment(horizontal: .Left, vertical: .Top))
+        collectionView.setupSectionAndLayout(section)
 
         let cell1 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 1))
         XCTAssertEqual(cell1?.frame, CGRect(x: 0, y: 0, width: 50, height: 50))
@@ -67,15 +59,12 @@ extension BrickAlignmentTests {
     }
 
     func testThatLeftAlignmentBricksWithInsets() {
-        collectionView.registerBrickClass(DummyBrick.self)
-
         let section = BrickSection(bricks: [
             DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 50)),
             DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 50)),
             DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 50)),
-            ], inset: 5, edgeInsets: UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10), alignment: .Left)
-        collectionView.setSection(section)
-        collectionView.layoutSubviews()
+            ], inset: 5, edgeInsets: UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10), alignment: BrickAlignment(horizontal: .Left, vertical: .Top))
+        collectionView.setupSectionAndLayout(section)
 
         let cell1 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 1))
         XCTAssertEqual(cell1?.frame, CGRect(x: 10, y: 0, width: 50, height: 50))
@@ -87,17 +76,14 @@ extension BrickAlignmentTests {
     }
 
     func testThatLeftAlignmentBricksWithInsetsAndSection() {
-        collectionView.registerBrickClass(DummyBrick.self)
-
         let section = BrickSection(bricks: [
             BrickSection(width: .Fixed(size: 50), bricks: [
                 DummyBrick(height: .Fixed(size: 50))
                 ]),
             DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 50)),
             DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 50)),
-            ], inset: 5, edgeInsets: UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10), alignment: .Left)
-        collectionView.setSection(section)
-        collectionView.layoutSubviews()
+            ], inset: 5, edgeInsets: UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10), alignment: BrickAlignment(horizontal: .Left, vertical: .Top))
+        collectionView.setupSectionAndLayout(section)
 
         let cell1 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 1))
         XCTAssertEqual(cell1?.frame, CGRect(x: 10, y: 0, width: 50, height: 50))
@@ -115,28 +101,22 @@ extension BrickAlignmentTests {
 extension BrickAlignmentTests {
 
     func testThatRightAlignDoesnChangeDefaultBehavior() {
-        collectionView.registerBrickClass(DummyBrick.self)
-
         let section = BrickSection(bricks: [
             DummyBrick(height: .Fixed(size: 50)),
-            ], inset: 10, edgeInsets: UIEdgeInsets(top: 5, left: 5, bottom: 5, right: 5), alignment: .Right)
-        collectionView.setSection(section)
-        collectionView.layoutSubviews()
+            ], inset: 10, edgeInsets: UIEdgeInsets(top: 5, left: 5, bottom: 5, right: 5), alignment: BrickAlignment(horizontal: .Right, vertical: .Top))
+        collectionView.setupSectionAndLayout(section)
 
         let cell1 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 1))
         XCTAssertEqual(cell1?.frame, CGRect(x: 5, y: 5, width: 310, height: 50))
     }
 
     func testThatRightAlignmentBricks() {
-        collectionView.registerBrickClass(DummyBrick.self)
-
         let section = BrickSection(bricks: [
             DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 50)),
             DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 50)),
             DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 50)),
-            ], alignment: .Right)
-        collectionView.setSection(section)
-        collectionView.layoutSubviews()
+            ], alignment: BrickAlignment(horizontal: .Right, vertical: .Top))
+        collectionView.setupSectionAndLayout(section)
 
         let cell1 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 1))
         XCTAssertEqual(cell1?.frame, CGRect(x: 170, y: 0, width: 50, height: 50))
@@ -148,15 +128,12 @@ extension BrickAlignmentTests {
     }
 
     func testThatRightAlignmentBricksWithInsets() {
-        collectionView.registerBrickClass(DummyBrick.self)
-
         let section = BrickSection(bricks: [
             DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 50)),
             DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 50)),
             DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 50)),
-            ], inset: 5, edgeInsets: UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10), alignment: .Right)
-        collectionView.setSection(section)
-        collectionView.layoutSubviews()
+            ], inset: 5, edgeInsets: UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10), alignment: BrickAlignment(horizontal: .Right, vertical: .Top))
+        collectionView.setupSectionAndLayout(section)
 
         let cell1 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 1))
         XCTAssertEqual(cell1?.frame, CGRect(x: 150, y: 0, width: 50, height: 50))
@@ -168,17 +145,14 @@ extension BrickAlignmentTests {
     }
 
     func testThatRightAlignmentBricksWithInsetsAndSection() {
-        collectionView.registerBrickClass(DummyBrick.self)
-
         let section = BrickSection(bricks: [
             BrickSection(width: .Fixed(size: 50), bricks: [
                 DummyBrick(height: .Fixed(size: 50))
                 ]),
             DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 50)),
             DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 50)),
-            ], inset: 5, edgeInsets: UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10), alignment: .Right)
-        collectionView.setSection(section)
-        collectionView.layoutSubviews()
+            ], inset: 5, edgeInsets: UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10), alignment: BrickAlignment(horizontal: .Right, vertical: .Top))
+        collectionView.setupSectionAndLayout(section)
 
         let cell1 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 1))
         XCTAssertEqual(cell1?.frame, CGRect(x: 150, y: 0, width: 50, height: 50))
@@ -192,17 +166,14 @@ extension BrickAlignmentTests {
     }
 
     func testThatRightAlignmentNestedBricksWithInsetsAndSection() {
-        collectionView.registerBrickClass(DummyBrick.self)
-
         let section = BrickSection(bricks: [
             BrickSection(bricks: [
                 DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 50)),
                 DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 50)),
                 DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 50)),
-                ], alignment: .Right),
+                ], alignment: BrickAlignment(horizontal: .Right, vertical: .Top)),
             ], inset: 5, edgeInsets: UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10))
-        collectionView.setSection(section)
-        collectionView.layoutSubviews()
+        collectionView.setupSectionAndLayout(section)
 
         let cell1 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 2))
         XCTAssertEqual(cell1?.frame, CGRect(x: 160, y: 0, width: 50, height: 50))
@@ -214,18 +185,14 @@ extension BrickAlignmentTests {
     }
 
     func testThatRightAlignmentNestedBricksWithInsetsAndSectionInset() {
-        collectionView.registerBrickClass(DummyBrick.self)
-
         let section = BrickSection(bricks: [
             BrickSection(bricks: [
                 DummyBrick(width: .Fixed(size: 85), height: .Fixed(size: 50)),
                 DummyBrick(width: .Fixed(size: 85), height: .Fixed(size: 50)),
                 DummyBrick(width: .Fixed(size: 85), height: .Fixed(size: 50))
-                ], inset: 10, alignment: .Right)
+                ], inset: 10, alignment: BrickAlignment(horizontal: .Right, vertical: .Top))
             ], inset: 10, edgeInsets: UIEdgeInsets(top: 20, left: 20, bottom: 20, right: 20))
-
-        collectionView.setSection(section)
-        collectionView.layoutSubviews()
+        collectionView.setupSectionAndLayout(section)
 
         let cell1 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 2))
         XCTAssertEqual(cell1?.frame, CGRect(x: 25, y: 20, width: 85, height: 50))
@@ -240,28 +207,22 @@ extension BrickAlignmentTests {
 extension BrickAlignmentTests {
 
     func testThatCenterAlignDoesnChangeDefaultBehavior() {
-        collectionView.registerBrickClass(DummyBrick.self)
-
         let section = BrickSection(bricks: [
             DummyBrick(height: .Fixed(size: 50)),
-            ], inset: 10, edgeInsets: UIEdgeInsets(top: 5, left: 5, bottom: 5, right: 5), alignment: .Center)
-        collectionView.setSection(section)
-        collectionView.layoutSubviews()
+            ], inset: 10, edgeInsets: UIEdgeInsets(top: 5, left: 5, bottom: 5, right: 5), alignment: BrickAlignment(horizontal: .Center, vertical: .Top))
+        collectionView.setupSectionAndLayout(section)
 
         let cell1 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 1))
         XCTAssertEqual(cell1?.frame, CGRect(x: 5, y: 5, width: 310, height: 50))
     }
 
     func testThatCenterAlignmentBricks() {
-        collectionView.registerBrickClass(DummyBrick.self)
-
         let section = BrickSection(bricks: [
             DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 50)),
             DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 50)),
             DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 50)),
-            ], alignment: .Center)
-        collectionView.setSection(section)
-        collectionView.layoutSubviews()
+            ], alignment: BrickAlignment(horizontal: .Center, vertical: .Top))
+        collectionView.setupSectionAndLayout(section)
 
         let cell1 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 1))
         XCTAssertEqual(cell1?.frame, CGRect(x: 85, y: 0, width: 50, height: 50))
@@ -273,15 +234,12 @@ extension BrickAlignmentTests {
     }
 
     func testThatCenterAlignmentBricksWithInsets() {
-        collectionView.registerBrickClass(DummyBrick.self)
-
         let section = BrickSection(bricks: [
             DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 50)),
             DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 50)),
             DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 50)),
-            ], inset: 5, edgeInsets: UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10), alignment: .Center)
-        collectionView.setSection(section)
-        collectionView.layoutSubviews()
+            ], inset: 5, edgeInsets: UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10), alignment: BrickAlignment(horizontal: .Center, vertical: .Top))
+        collectionView.setupSectionAndLayout(section)
 
         let cell1 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 1))
         XCTAssertEqual(cell1?.frame, CGRect(x: 80, y: 0, width: 50, height: 50))
@@ -293,17 +251,14 @@ extension BrickAlignmentTests {
     }
 
     func testThatCenterAlignmentBricksWithInsetsAndSection() {
-        collectionView.registerBrickClass(DummyBrick.self)
-
         let section = BrickSection(bricks: [
             BrickSection(width: .Fixed(size: 50), bricks: [
                 DummyBrick(height: .Fixed(size: 50))
                 ]),
             DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 50)),
             DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 50)),
-            ], inset: 5, edgeInsets: UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10), alignment: .Center)
-        collectionView.setSection(section)
-        collectionView.layoutSubviews()
+            ], inset: 5, edgeInsets: UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10), alignment: BrickAlignment(horizontal: .Center, vertical: .Top))
+        collectionView.setupSectionAndLayout(section)
 
         let cell1 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 1))
         XCTAssertEqual(cell1?.frame, CGRect(x: 80, y: 0, width: 50, height: 50))
@@ -317,15 +272,12 @@ extension BrickAlignmentTests {
     }
 
     func testThatAddingABrickAlignsProperly() {
-        collectionView.registerBrickClass(DummyBrick.self)
-
         let section = BrickSection(bricks: [
             DummyBrick("BRICK", width: .Ratio(ratio: 1/3), height: .Fixed(size: 50)),
-            ], edgeInsets: UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10), alignment: .Center)
+            ], edgeInsets: UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10), alignment: BrickAlignment(horizontal: .Center, vertical: .Top))
         let repeatCountDataSource = FixedRepeatCountDataSource(repeatCountHash: ["BRICK": 2])
         section.repeatCountDataSource = repeatCountDataSource
-        collectionView.setSection(section)
-        collectionView.layoutSubviews()
+        collectionView.setupSectionAndLayout(section)
 
         repeatCountDataSource.repeatCountHash = ["BRICK": 3]
         let expectation = expectationWithDescription("Invalidat Bricks")
@@ -350,28 +302,22 @@ extension BrickAlignmentTests {
 extension BrickAlignmentTests {
 
     func testThatJustifiedAlignDoesnChangeDefaultBehavior() {
-        collectionView.registerBrickClass(DummyBrick.self)
-
         let section = BrickSection(bricks: [
             DummyBrick(height: .Fixed(size: 50)),
-            ], inset: 10, edgeInsets: UIEdgeInsets(top: 5, left: 5, bottom: 5, right: 5), alignment: .Justified)
-        collectionView.setSection(section)
-        collectionView.layoutSubviews()
+            ], inset: 10, edgeInsets: UIEdgeInsets(top: 5, left: 5, bottom: 5, right: 5), alignment: BrickAlignment(horizontal: .Justified, vertical: .Top))
+        collectionView.setupSectionAndLayout(section)
 
         let cell1 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 1))
         XCTAssertEqual(cell1?.frame, CGRect(x: 5, y: 5, width: 310, height: 50))
     }
 
     func testThatJustifiedAlignmentBricks() {
-        collectionView.registerBrickClass(DummyBrick.self)
-
         let section = BrickSection(bricks: [
             DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 50)),
             DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 50)),
             DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 50)),
-            ], alignment: .Justified)
-        collectionView.setSection(section)
-        collectionView.layoutSubviews()
+            ], alignment: BrickAlignment(horizontal: .Justified, vertical: .Top))
+        collectionView.setupSectionAndLayout(section)
 
         let cell1 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 1))
         XCTAssertEqual(cell1?.frame, CGRect(x: 0, y: 0, width: 50, height: 50))
@@ -383,15 +329,12 @@ extension BrickAlignmentTests {
     }
 
     func testThatJustifiedAlignmentBricksWithInsets() {
-        collectionView.registerBrickClass(DummyBrick.self)
-
         let section = BrickSection(bricks: [
             DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 50)),
             DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 50)),
             DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 50)),
-            ], inset: 5, edgeInsets: UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10), alignment: .Justified)
-        collectionView.setSection(section)
-        collectionView.layoutSubviews()
+            ], inset: 5, edgeInsets: UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10), alignment: BrickAlignment(horizontal: .Justified, vertical: .Top))
+        collectionView.setupSectionAndLayout(section)
 
         let cell1 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 1))
         XCTAssertEqual(cell1?.frame, CGRect(x: 10, y: 0, width: 50, height: 50))
@@ -402,17 +345,14 @@ extension BrickAlignmentTests {
     }
 
     func testThatJustifiedAlignmentBricksWithInsetsAndSection() {
-        collectionView.registerBrickClass(DummyBrick.self)
-
         let section = BrickSection(bricks: [
             BrickSection(width: .Fixed(size: 50), bricks: [
                 DummyBrick(height: .Fixed(size: 50))
                 ]),
             DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 50)),
             DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 50)),
-            ], inset: 5, edgeInsets: UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10), alignment: .Justified)
-        collectionView.setSection(section)
-        collectionView.layoutSubviews()
+            ], inset: 5, edgeInsets: UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10), alignment: BrickAlignment(horizontal: .Justified, vertical: .Top))
+        collectionView.setupSectionAndLayout(section)
 
         let cell1 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 1))
         XCTAssertEqual(cell1?.frame, CGRect(x: 10, y: 0, width: 50, height: 50))
@@ -422,5 +362,249 @@ extension BrickAlignmentTests {
         XCTAssertEqual(cell2?.frame, CGRect(x: 135, y: 0, width: 50, height: 50))
         let cell3 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 2, inSection: 1))
         XCTAssertEqual(cell3?.frame, CGRect(x: 260, y: 0, width: 50, height: 50))
+    }
+}
+
+// MARK: - Top Align
+extension BrickAlignmentTests {
+
+    func testThatTopAlignDoesnChangeDefaultBehavior() {
+        let section = BrickSection(bricks: [
+            DummyBrick(height: .Fixed(size: 50)),
+            ], inset: 10, edgeInsets: UIEdgeInsets(top: 5, left: 5, bottom: 5, right: 5), alignment: BrickAlignment(horizontal: .Left, vertical: .Top))
+        collectionView.setupSectionAndLayout(section)
+
+        let cell1 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 1))
+        XCTAssertEqual(cell1?.frame, CGRect(x: 5, y: 5, width: 310, height: 50))
+    }
+
+    func testThatTopAlignIgnoresHiddenBricks() {
+        let hideBehaviorDataSource = FixedHideBehaviorDataSource(indexPaths: [NSIndexPath(forItem: 0, inSection: 1)])
+        collectionView.layout.hideBehaviorDataSource = hideBehaviorDataSource
+
+        let section = BrickSection(bricks: [
+            DummyBrick(height: .Fixed(size: 50)),
+            DummyBrick(height: .Fixed(size: 50)),
+            ], inset: 10, edgeInsets: UIEdgeInsets(top: 5, left: 5, bottom: 5, right: 5), alignRowHeights: true, alignment: BrickAlignment(horizontal: .Left, vertical: .Top))
+        collectionView.setupSectionAndLayout(section)
+
+        let cell1 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 1))
+        XCTAssertNil(cell1)
+        let cell2 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 1, inSection: 1))
+        XCTAssertEqual(cell2?.frame, CGRect(x: 5, y: 5, width: 310, height: 50))
+    }
+
+    func testThatTopAlignmentBricks() {
+        let section = BrickSection(bricks: [
+            DummyBrick(width: .Ratio(ratio: 0.5), height: .Fixed(size: 50)),
+            DummyBrick(width: .Ratio(ratio: 0.5), height: .Fixed(size: 10)),
+            ], alignment: BrickAlignment(horizontal: .Left, vertical: .Top))
+        collectionView.setupSectionAndLayout(section)
+
+        let cell1 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 1))
+        XCTAssertEqual(cell1?.frame, CGRect(x: 0, y: 0, width: 160, height: 50))
+        let cell2 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 1, inSection: 1))
+        XCTAssertEqual(cell2?.frame, CGRect(x: 160, y: 0, width: 160, height: 10))
+    }
+
+    func testThatTopAlignmentBricksWithInsets() {
+        let section = BrickSection(bricks: [
+            DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 50)),
+            DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 30)),
+            DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 20)),
+            ], inset: 5, edgeInsets: UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10), alignment: BrickAlignment(horizontal: .Left, vertical: .Top))
+        collectionView.setupSectionAndLayout(section)
+
+        let cell1 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 1))
+        XCTAssertEqual(cell1?.frame, CGRect(x: 10, y: 10, width: 50, height: 50))
+        let cell2 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 1, inSection: 1))
+        XCTAssertEqual(cell2?.frame, CGRect(x: 65, y: 10, width: 50, height: 30))
+        let cell3 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 2, inSection: 1))
+        XCTAssertEqual(cell3?.frame, CGRect(x: 120, y: 10, width: 50, height: 20))
+
+    }
+
+    func testThatTopAlignmentBricksWithInsetsAndSection() {
+        let section = BrickSection(bricks: [
+            BrickSection(width: .Fixed(size: 50), bricks: [
+                DummyBrick(height: .Fixed(size: 50))
+                ]),
+            DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 30)),
+            DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 20)),
+            ], inset: 5, edgeInsets: UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10), alignment: BrickAlignment(horizontal: .Left, vertical: .Top))
+        collectionView.setupSectionAndLayout(section)
+
+        let cell1 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 1))
+        XCTAssertEqual(cell1?.frame, CGRect(x: 10, y: 10, width: 50, height: 50))
+        let cell12 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 2))
+        XCTAssertEqual(cell12?.frame, CGRect(x: 10, y: 10, width: 50, height: 50))
+        let cell2 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 1, inSection: 1))
+        XCTAssertEqual(cell2?.frame, CGRect(x: 65, y: 10, width: 50, height: 30))
+        let cell3 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 2, inSection: 1))
+        XCTAssertEqual(cell3?.frame, CGRect(x: 120, y: 10, width: 50, height: 20))
+        
+    }
+
+}
+
+// MARK: - Center Align
+extension BrickAlignmentTests {
+
+    func testThatVerticalCenterAlignDoesnChangeDefaultBehavior() {
+        let section = BrickSection(bricks: [
+            DummyBrick(height: .Fixed(size: 50)),
+            ], inset: 10, edgeInsets: UIEdgeInsets(top: 5, left: 5, bottom: 5, right: 5), alignment: BrickAlignment(horizontal: .Left, vertical: .Center))
+        collectionView.setupSectionAndLayout(section)
+
+        let cell1 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 1))
+        XCTAssertEqual(cell1?.frame, CGRect(x: 5, y: 5, width: 310, height: 50))
+    }
+
+    func testThatVerticalCenterAlignIgnoresHiddenBricks() {
+        let hideBehaviorDataSource = FixedHideBehaviorDataSource(indexPaths: [NSIndexPath(forItem: 0, inSection: 1)])
+        collectionView.layout.hideBehaviorDataSource = hideBehaviorDataSource
+
+        let section = BrickSection(bricks: [
+            DummyBrick(height: .Fixed(size: 50)),
+            DummyBrick(height: .Fixed(size: 50)),
+            ], inset: 10, edgeInsets: UIEdgeInsets(top: 5, left: 5, bottom: 5, right: 5), alignRowHeights: true, alignment: BrickAlignment(horizontal: .Left, vertical: .Center))
+        collectionView.setupSectionAndLayout(section)
+
+        let cell1 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 1))
+        XCTAssertNil(cell1)
+        let cell2 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 1, inSection: 1))
+        XCTAssertEqual(cell2?.frame, CGRect(x: 5, y: 5, width: 310, height: 50))
+    }
+
+    func testThatVerticalCenterAlignmentBricks() {
+        let section = BrickSection(bricks: [
+            DummyBrick(width: .Ratio(ratio: 0.5), height: .Fixed(size: 50)),
+            DummyBrick(width: .Ratio(ratio: 0.5), height: .Fixed(size: 10)),
+            ], alignment: BrickAlignment(horizontal: .Left, vertical: .Center))
+        collectionView.setupSectionAndLayout(section)
+
+        let cell1 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 1))
+        XCTAssertEqual(cell1?.frame, CGRect(x: 0, y: 0, width: 160, height: 50))
+        let cell2 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 1, inSection: 1))
+        XCTAssertEqual(cell2?.frame, CGRect(x: 160, y: 20, width: 160, height: 10))
+    }
+
+    func testThatVerticalCenterAlignmentBricksWithInsets() {
+        let section = BrickSection(bricks: [
+            DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 50)),
+            DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 30)),
+            DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 20)),
+            ], inset: 5, edgeInsets: UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10), alignment: BrickAlignment(horizontal: .Left, vertical: .Center))
+        collectionView.setupSectionAndLayout(section)
+
+        let cell1 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 1))
+        XCTAssertEqual(cell1?.frame, CGRect(x: 10, y: 10, width: 50, height: 50))
+        let cell2 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 1, inSection: 1))
+        XCTAssertEqual(cell2?.frame, CGRect(x: 65, y: 20, width: 50, height: 30))
+        let cell3 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 2, inSection: 1))
+        XCTAssertEqual(cell3?.frame, CGRect(x: 120, y: 25, width: 50, height: 20))
+
+    }
+
+    func testThatVerticalCenterAlignmentBricksWithInsetsAndSection() {
+        let section = BrickSection(bricks: [
+            BrickSection(width: .Fixed(size: 50), bricks: [
+                DummyBrick(height: .Fixed(size: 50))
+                ]),
+            DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 30)),
+            DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 20)),
+            ], inset: 5, edgeInsets: UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10), alignment: BrickAlignment(horizontal: .Left, vertical: .Center))
+        collectionView.setupSectionAndLayout(section)
+
+        let cell1 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 1))
+        XCTAssertEqual(cell1?.frame, CGRect(x: 10, y: 10, width: 50, height: 50))
+        let cell12 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 2))
+        XCTAssertEqual(cell12?.frame, CGRect(x: 10, y: 10, width: 50, height: 50))
+        let cell2 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 1, inSection: 1))
+        XCTAssertEqual(cell2?.frame, CGRect(x: 65, y: 20, width: 50, height: 30))
+        let cell3 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 2, inSection: 1))
+        XCTAssertEqual(cell3?.frame, CGRect(x: 120, y: 25, width: 50, height: 20))
+        
+    }
+}
+
+// MARK: - Bottom Align
+extension BrickAlignmentTests {
+
+    func testThatBottomAlignDoesnChangeDefaultBehavior() {
+        let section = BrickSection(bricks: [
+            DummyBrick(height: .Fixed(size: 50)),
+            ], inset: 10, edgeInsets: UIEdgeInsets(top: 5, left: 5, bottom: 5, right: 5), alignment: BrickAlignment(horizontal: .Left, vertical: .Bottom))
+        collectionView.setupSectionAndLayout(section)
+
+        let cell1 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 1))
+        XCTAssertEqual(cell1?.frame, CGRect(x: 5, y: 5, width: 310, height: 50))
+    }
+
+    func testThatBottomAlignIgnoresHiddenBricks() {
+        let hideBehaviorDataSource = FixedHideBehaviorDataSource(indexPaths: [NSIndexPath(forItem: 0, inSection: 1)])
+        collectionView.layout.hideBehaviorDataSource = hideBehaviorDataSource
+
+        let section = BrickSection(bricks: [
+            DummyBrick(height: .Fixed(size: 50)),
+            DummyBrick(height: .Fixed(size: 50)),
+            ], inset: 10, edgeInsets: UIEdgeInsets(top: 5, left: 5, bottom: 5, right: 5), alignRowHeights: true, alignment: BrickAlignment(horizontal: .Left, vertical: .Bottom))
+        collectionView.setupSectionAndLayout(section)
+
+        let cell1 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 1))
+        XCTAssertNil(cell1)
+        let cell2 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 1, inSection: 1))
+        XCTAssertEqual(cell2?.frame, CGRect(x: 5, y: 5, width: 310, height: 50))
+    }
+
+    func testThatBottomAlignmentBricks() {
+        let section = BrickSection(bricks: [
+            DummyBrick(width: .Ratio(ratio: 0.5), height: .Fixed(size: 50)),
+            DummyBrick(width: .Ratio(ratio: 0.5), height: .Fixed(size: 10)),
+            ], alignment: BrickAlignment(horizontal: .Left, vertical: .Bottom))
+        collectionView.setupSectionAndLayout(section)
+
+        let cell1 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 1))
+        XCTAssertEqual(cell1?.frame, CGRect(x: 0, y: 0, width: 160, height: 50))
+        let cell2 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 1, inSection: 1))
+        XCTAssertEqual(cell2?.frame, CGRect(x: 160, y: 40, width: 160, height: 10))
+    }
+
+    func testThatBottomAlignmentBricksWithInsets() {
+        let section = BrickSection(bricks: [
+            DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 50)),
+            DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 30)),
+            DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 20)),
+            ], inset: 5, edgeInsets: UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10), alignment: BrickAlignment(horizontal: .Left, vertical: .Bottom))
+        collectionView.setupSectionAndLayout(section)
+
+        let cell1 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 1))
+        XCTAssertEqual(cell1?.frame, CGRect(x: 10, y: 10, width: 50, height: 50))
+        let cell2 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 1, inSection: 1))
+        XCTAssertEqual(cell2?.frame, CGRect(x: 65, y: 30, width: 50, height: 30))
+        let cell3 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 2, inSection: 1))
+        XCTAssertEqual(cell3?.frame, CGRect(x: 120, y: 40, width: 50, height: 20))
+
+    }
+
+    func testThatBottomAlignmentBricksWithInsetsAndSection() {
+        let section = BrickSection(bricks: [
+            BrickSection(width: .Fixed(size: 50), bricks: [
+                DummyBrick(height: .Fixed(size: 50))
+                ]),
+            DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 30)),
+            DummyBrick(width: .Fixed(size: 50), height: .Fixed(size: 20)),
+            ], inset: 5, edgeInsets: UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10), alignment: BrickAlignment(horizontal: .Left, vertical: .Bottom))
+        collectionView.setupSectionAndLayout(section)
+
+        let cell1 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 1))
+        XCTAssertEqual(cell1?.frame, CGRect(x: 10, y: 10, width: 50, height: 50))
+        let cell12 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 2))
+        XCTAssertEqual(cell12?.frame, CGRect(x: 10, y: 10, width: 50, height: 50))
+        let cell2 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 1, inSection: 1))
+        XCTAssertEqual(cell2?.frame, CGRect(x: 65, y: 30, width: 50, height: 30))
+        let cell3 = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: 2, inSection: 1))
+        XCTAssertEqual(cell3?.frame, CGRect(x: 120, y: 40, width: 50, height: 20))
+        
     }
 }

--- a/Tests/Utils/DataSources.swift
+++ b/Tests/Utils/DataSources.swift
@@ -190,7 +190,7 @@ class FixedBrickLayoutSectionDataSource: NSObject, BrickLayoutSectionDataSource 
     }
 
     func aligment(in section: BrickLayoutSection) -> BrickAlignment {
-        return .Left
+        return BrickAlignment(horizontal: .Left, vertical: .Top)
     }
 
     var scrollDirection: UICollectionViewScrollDirection = .Vertical


### PR DESCRIPTION
- Changed BrickAlignment from an `enum` to a `struct` that holds vertical and horizontal alignment
- Introduced `BrickHorizontalAlignment` enum
- Introduced `BrickVerticalAlignment` enum
- Tests

Fixes #69