### PR TITLE
Fixed ButtonBrick by adding action to UIButton

### DIFF
--- a/Source/Bricks/Button/ButtonBrick.swift
+++ b/Source/Bricks/Button/ButtonBrick.swift
@@ -152,6 +152,7 @@ public class ButtonBrickCell: GenericBrickCell, Bricklike {
 
         if !fromNib {
             self.button = self.genericContentView as! UIButton
+            self.button.addTarget(self, action: #selector(didTapButton(_:)), forControlEvents: .TouchUpInside)
         }
 
         brick.dataSource?.configureButtonBrick(self)

--- a/Tests/Bricks/ButtonBrickTests.swift
+++ b/Tests/Bricks/ButtonBrickTests.swift
@@ -19,10 +19,8 @@ class ButtonBrickTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
+        continueAfterFailure = false
         brickCollectionView = BrickCollectionView(frame: CGRect(x: 0, y: 0, width: 320, height: 480))
-    }
-    func noOp() {
-        // no op for mock gesture
     }
 
     func setupButtonBrickWithModel(model: ButtonBrickCellModel) -> ButtonBrickCell? {
@@ -231,7 +229,10 @@ class ButtonBrickTests: XCTestCase {
         let cell = setupSection(ButtonBrick(ButtonBrickIdentifier, dataSource: FixedButtonDataSource(), delegate: delegate))
         
         // Ideally cell?.button?.sendActionsForControlEvents(.TouchUpInside) is called, but this doesn't work in XCTests
-        cell?.didTapButton(cell!.button!)
+        let actions = cell?.button.actionsForTarget(cell, forControlEvent: .TouchUpInside)
+        XCTAssertEqual(actions?.count, 1)
+        cell!.performSelector(Selector(actions!.first!), withObject: cell!.button)
+        
         XCTAssertTrue(delegate.buttonTouched)
     }
 


### PR DESCRIPTION
Added action to the UIButton when loaded through GenericBrick<UIButton>

Fixes #75