### PR TITLE
Optimized brick calculation

### DIFF
--- a/Source/Layout/BrickLayoutSection.swift
+++ b/Source/Layout/BrickLayoutSection.swift
@@ -8,6 +8,8 @@
 
 import UIKit
 
+private let PrecisionAccuracy: CGFloat = 0.0000001
+
 protocol BrickLayoutSectionDelegate: class {
     func brickLayoutSection(section: BrickLayoutSection, didCreateAttributes attributes: BrickLayoutAttributes)
 }
@@ -580,7 +582,9 @@ internal class BrickLayoutSection {
         let shouldBeOnNextRow: Bool
         switch dataSource.scrollDirection {
         case .Horizontal: shouldBeOnNextRow = false
-        case .Vertical: shouldBeOnNextRow = (x + width - origin.x) > (sectionWidth - edgeInsets.right)
+        case .Vertical:
+            let leftOverSpace = (sectionWidth - edgeInsets.right) - (x + width - origin.x)
+            shouldBeOnNextRow = leftOverSpace < 0 && fabs(leftOverSpace) > PrecisionAccuracy
         }
 
         var nextY: CGFloat = y

--- a/Tests/Layout/BrickFlowLayoutTests.swift
+++ b/Tests/Layout/BrickFlowLayoutTests.swift
@@ -214,6 +214,19 @@ class BrickFlowLayoutTests: BrickFlowLayoutBaseTests {
         XCTAssertEqual(delegate.updatedIndexPaths, [NSIndexPath(forItem: 0, inSection: 1)])
     }
 
+    func testPrecision() {
+        let brickView = BrickCollectionView(frame: CGRect(x: 0, y: 0, width: 1024, height: 768))
+        let section = BrickSection(bricks: [
+            DummyBrick("Dummy", width: .Ratio(ratio: 1/5), height: .Fixed(size: 50))
+            ], inset: 8, edgeInsets: UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8))
+        let repeatCount = FixedRepeatCountDataSource(repeatCountHash: ["Dummy": 5])
+        section.repeatCountDataSource = repeatCount
+        brickView.setupSectionAndLayout(section)
+
+        let cell = brickView.cellForItemAtIndexPath(NSIndexPath(forItem: 4, inSection: 1))
+        XCTAssertEqualWithAccuracy(cell?.frame, CGRect(x: 820.8, y: 8, width: 195.2, height: 50), accuracy: CGRect(x: 0.1, y: 0.1, width: 0.1, height: 0.1))
+    }
+
 }
 
 class FixedDelegate: BrickLayoutDelegate {


### PR DESCRIPTION
Added precision when analyzing if a brick should be put on the next row

CGFloat can be very precise, which could lead to a difference of `-1.13686837721616e-13` between two values, that are actually the same. This is now fixed by adding in a precision accuracy of `0.0000001`

Fixes #77 