### PR TITLE
Add `nibIdentifiers` to the BrickSection

### DIFF
--- a/Source/Models/BrickModels.swift
+++ b/Source/Models/BrickModels.swift
@@ -154,6 +154,8 @@ public class BrickSection: Brick {
     /// These nibs will be registered, when setting this BrickSection on a BrickCollectionView
     public var nibIdentifiers: [String: UINib]?
 
+    public internal(set) weak var brickCollectionView: BrickCollectionView?
+
     public weak var repeatCountDataSource: BrickRepeatCountDataSource? {
         didSet {
             sectionIndexPaths.removeAll()

--- a/Source/Models/BrickModels.swift
+++ b/Source/Models/BrickModels.swift
@@ -150,6 +150,10 @@ public class BrickSection: Brick {
     internal private(set) var sectionCount: Int = 0
     internal private(set) var sectionIndexPaths: [CollectionInfo: [Int: NSIndexPath]] = [:] // Variable that keeps track of the indexpaths of the sections
 
+    /// Optional dictionary that holds the identifier of a brick as a key and the value is the nib that should be used for that brick
+    /// These nibs will be registered, when setting this BrickSection on a BrickCollectionView
+    public var nibIdentifiers: [String: UINib]?
+
     public weak var repeatCountDataSource: BrickRepeatCountDataSource? {
         didSet {
             sectionIndexPaths.removeAll()

--- a/Source/ViewControllers/BrickCollectionView.swift
+++ b/Source/ViewControllers/BrickCollectionView.swift
@@ -486,6 +486,7 @@ public class BrickCollectionView: UICollectionView {
 
     /// Register the bricks in a section
     private func registerBricks(for section: BrickSection, nibIdentifiers: [String: UINib]?) {
+        section.brickCollectionView = self
         for brick in section.bricks {
             if let brickSection = brick as? BrickSection {
                 registerBricks(for: brickSection, nibIdentifiers: brickSection.nibIdentifiers ?? nibIdentifiers)

--- a/Tests/Utils/XCTests.swift
+++ b/Tests/Utils/XCTests.swift
@@ -129,16 +129,6 @@ extension BrickCollectionView {
     }
 
     func setupSectionAndLayout(section: BrickSection) {
-        self.registerBrickClass(CollectionBrick.self)
-        self.registerBrickClass(DummyBrick.self)
-        self.registerBrickClass(LabelBrick.self)
-        self.registerBrickClass(ButtonBrick.self)
-        self.registerBrickClass(ImageBrick.self)
-
-        self.registerBrickClass(GenericBrick<UILabel>.self)
-        self.registerBrickClass(GenericBrick<UIButton>.self)
-        self.registerBrickClass(GenericBrick<UIImageView>.self)
-
         self.setSection(section)
         self.layoutSubviews()
     }

--- a/Tests/ViewControllers/BrickCollectionViewTests.swift
+++ b/Tests/ViewControllers/BrickCollectionViewTests.swift
@@ -625,4 +625,38 @@ class BrickCollectionViewTests: XCTestCase {
         XCTAssertNotNil(brickView.cellForItemAtIndexPath(NSIndexPath(forItem: 1, inSection: 1)))
     }
 
+    func testNibIdentifiers() {
+        let brick = LabelBrick("Label", text: "Hello")
+        let section = BrickSection(bricks: [brick])
+        section.nibIdentifiers = [
+            "Label": LabelBrickNibs.Image
+        ]
+        brickView.setupSectionAndLayout(section)
+
+        let cell = brickView.cellForItemAtIndexPath(brickView.indexPathsForBricksWithIdentifier("Label").first!) as? LabelBrickCell
+        XCTAssertNotNil(cell?.imageView)
+    }
+
+    func testNestedNibIdentifiers() {
+        let brick = LabelBrick("Label", text: "Hello")
+        let section = BrickSection(bricks: [BrickSection(bricks: [brick])])
+        section.nibIdentifiers = [
+            "Label": LabelBrickNibs.Image
+        ]
+        brickView.setupSectionAndLayout(section)
+
+        let cell = brickView.cellForItemAtIndexPath(brickView.indexPathsForBricksWithIdentifier("Label").first!) as? LabelBrickCell
+        XCTAssertNotNil(cell?.imageView)
+    }
+
+    func testClassNibIdentifiers() {
+        let brick = LabelBrick("Label", text: "Hello")
+        brickView.registerBrickClass(LabelBrick.self, nib: LabelBrickNibs.Image)
+        let section = BrickSection(bricks: [brick])
+        brickView.setupSectionAndLayout(section)
+
+        let cell = brickView.cellForItemAtIndexPath(brickView.indexPathsForBricksWithIdentifier("Label").first!) as? LabelBrickCell
+        XCTAssertNotNil(cell?.imageView)
+    }
+
 }

--- a/Tests/ViewControllers/BrickCollectionViewTests.swift
+++ b/Tests/ViewControllers/BrickCollectionViewTests.swift
@@ -659,4 +659,29 @@ class BrickCollectionViewTests: XCTestCase {
         XCTAssertNotNil(cell?.imageView)
     }
 
+    func testThatBrickCollectionViewIsSetToTheSection() {
+        let brick = LabelBrick("Label", text: "Hello")
+        let section = BrickSection(bricks: [brick])
+        section.nibIdentifiers = [
+            "Label": LabelBrickNibs.Image
+        ]
+        brickView.setupSectionAndLayout(section)
+
+        XCTAssertEqual(section.brickCollectionView, brickView)
+    }
+
+    func testThatBrickCollectionViewIsSetToTheNestedSections() {
+        let brick = LabelBrick("Label", text: "Hello")
+        let innerSection = BrickSection(bricks: [brick])
+        let section = BrickSection(bricks: [innerSection ])
+        section.nibIdentifiers = [
+            "Label": LabelBrickNibs.Image
+        ]
+        brickView.setupSectionAndLayout(section)
+
+        XCTAssertEqual(section.brickCollectionView, brickView)
+        XCTAssertEqual(innerSection.brickCollectionView, brickView)
+    }
+
+
 }

--- a/Tests/ViewControllers/BrickViewControllerTests.swift
+++ b/Tests/ViewControllers/BrickViewControllerTests.swift
@@ -63,17 +63,6 @@ class BrickViewControllerTests: XCTestCase {
         XCTAssertTrue(viewController.brickRegistered)
     }
 
-    func testWithoutRegisteringBrick() {
-        let dummyBrick = DummyBrick("Brick 1")
-        expectFatalError("No Nib Found for \(dummyBrick)") {
-            let section = BrickSection(bricks: [
-                dummyBrick
-                ])
-            self.brickViewController.setSection(section)
-            self.brickViewController.brickCollectionView.layoutSubviews()
-        }
-    }
-
     func testWithSectionWithSameNameAsBrick() {
         let section = BrickSection("DummyBrick", bricks: [
             DummyBrick("Brick 1"),


### PR DESCRIPTION
You can now set `nibIdentifiers` to a BrickSection, so you don’t have to register Bricks upfront anymore

Fixes #90