### PR TITLE
isHidden property on Brick

### DIFF
--- a/Example/BrickKit-Example.xcodeproj/project.pbxproj
+++ b/Example/BrickKit-Example.xcodeproj/project.pbxproj
@@ -165,6 +165,8 @@
 		4E3BD8ED1DB521C200541900 /* CoverFlowViewScrollingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E3BD8EB1DB521C200541900 /* CoverFlowViewScrollingController.swift */; };
 		4E8E10F41DB569E100B5BD90 /* EmbeddedSpotlightSnapScrollingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E8E10F31DB569E100B5BD90 /* EmbeddedSpotlightSnapScrollingViewController.swift */; };
 		4E8E10F51DB569E100B5BD90 /* EmbeddedSpotlightSnapScrollingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E8E10F31DB569E100B5BD90 /* EmbeddedSpotlightSnapScrollingViewController.swift */; };
+		930C19391E63A21500D4CDDB /* IsHiddenBrickViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 930C19381E63A21500D4CDDB /* IsHiddenBrickViewController.swift */; };
+		930C193A1E63A21500D4CDDB /* IsHiddenBrickViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 930C19381E63A21500D4CDDB /* IsHiddenBrickViewController.swift */; };
 		93186B031DDE89610095C849 /* HugeRepeatBrickViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93186B021DDE89610095C849 /* HugeRepeatBrickViewController.swift */; };
 		93186B041DDE89610095C849 /* HugeRepeatBrickViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93186B021DDE89610095C849 /* HugeRepeatBrickViewController.swift */; };
 		93186B081DDE8A580095C849 /* HugeRepeatCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93186B071DDE8A580095C849 /* HugeRepeatCollectionViewController.swift */; };
@@ -362,6 +364,7 @@
 		4E3BD8E61DB51E1200541900 /* BrickIdentifiers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BrickIdentifiers.swift; sourceTree = "<group>"; };
 		4E3BD8EB1DB521C200541900 /* CoverFlowViewScrollingController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoverFlowViewScrollingController.swift; sourceTree = "<group>"; };
 		4E8E10F31DB569E100B5BD90 /* EmbeddedSpotlightSnapScrollingViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmbeddedSpotlightSnapScrollingViewController.swift; sourceTree = "<group>"; };
+		930C19381E63A21500D4CDDB /* IsHiddenBrickViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IsHiddenBrickViewController.swift; sourceTree = "<group>"; };
 		93186B021DDE89610095C849 /* HugeRepeatBrickViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HugeRepeatBrickViewController.swift; sourceTree = "<group>"; };
 		93186B071DDE8A580095C849 /* HugeRepeatCollectionViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HugeRepeatCollectionViewController.swift; sourceTree = "<group>"; };
 		932365661DF449A500BE5183 /* FillBrickViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FillBrickViewController.swift; sourceTree = "<group>"; };
@@ -574,6 +577,7 @@
 		4E3BD7891DB1316400541900 /* Interactive */ = {
 			isa = PBXGroup;
 			children = (
+				930C19381E63A21500D4CDDB /* IsHiddenBrickViewController.swift */,
 				4E3BD78A1DB1316400541900 /* AdvancedRepeatViewController.swift */,
 				4E3BD78B1DB1316400541900 /* BasicInteractiveViewController.swift */,
 				4E3BD78C1DB1316400541900 /* BrickCollectionInteractiveViewController.swift */,
@@ -982,6 +986,7 @@
 				4E3BD7C61DB1316400541900 /* DailySalesBrick.swift in Sources */,
 				4E3BD8041DB1316400541900 /* HorizontalScrollSectionBrickViewController.swift in Sources */,
 				4E3BD8461DB1316400541900 /* MultiSectionBrickViewController.swift in Sources */,
+				930C19391E63A21500D4CDDB /* IsHiddenBrickViewController.swift in Sources */,
 				4E3BD8081DB1316400541900 /* SimpleCollectionBrickViewController.swift in Sources */,
 				4E3BD8501DB1316400541900 /* SimpleRepeatHeightRatioViewController.swift in Sources */,
 				FCD401B61E203D080011173A /* ActivityIndicatorOverrideSource.swift in Sources */,
@@ -1059,6 +1064,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4E3BD8ED1DB521C200541900 /* CoverFlowViewScrollingController.swift in Sources */,
+				930C193A1E63A21500D4CDDB /* IsHiddenBrickViewController.swift in Sources */,
 				93D7E86A1DFB52830031A6C2 /* InteractiveAlignViewController.swift in Sources */,
 				4E3BD8011DB1316400541900 /* BaseRepeatBrickViewController.swift in Sources */,
 				4E3BD85D1DB1316400541900 /* StickingFooterBaseViewController.swift in Sources */,

--- a/Example/Source/Examples/Interactive/IsHiddenBrickViewController.swift
+++ b/Example/Source/Examples/Interactive/IsHiddenBrickViewController.swift
@@ -1,0 +1,84 @@
+//
+//  HideBrickViewController.swift
+//  BrickKit
+//
+//  Created by Ruben Cagnie on 6/16/16.
+//  Copyright © 2016 Wayfair LLC. All rights reserved.
+//
+
+import BrickKit
+
+class IsHiddenBrickViewController: BrickApp.BaseBrickController {
+
+    override class var title: String {
+        return "Hide Bricks with isHidden flag"
+    }
+    override class var subTitle: String {
+        return "Example of hiding bricks with the isHidden flag"
+    }
+
+    struct Identifiers {
+        static let HideBrickButton = "HideBrickButton"
+        static let HideSectionButton = "HideSectionButton"
+
+        static let SimpleBrick = "SimpleBrick"
+        static let SimpleSection = "SimpleSection"
+    }
+
+    var hideBrickButton: ButtonBrick!
+    var hideSectionButton: ButtonBrick!
+    var hiddenBrick: Brick!
+    var hiddenSection: BrickSection!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        hiddenBrick = LabelBrick(HideBrickViewController.Identifiers.SimpleBrick, backgroundColor: .brickGray3, dataSource: LabelBrickCellModel(text: "BRICK", configureCellBlock: LabelBrickCell.configure))
+        hideBrickButton = ButtonBrick(HideBrickViewController.Identifiers.HideBrickButton, backgroundColor: .brickGray1, title: titleForHideBrickButton) { [weak self] _ in
+            self?.hideBrick()
+        }
+
+        hiddenSection = BrickSection(HideBrickViewController.Identifiers.SimpleSection, backgroundColor: .brickGray3, bricks: [
+            LabelBrick(width: .Ratio(ratio: 0.5), backgroundColor: .brickGray5, dataSource: LabelBrickCellModel(text: "BRICK", configureCellBlock: LabelBrickCell.configure)),
+            LabelBrick(width: .Ratio(ratio: 0.5), backgroundColor: .brickGray5, dataSource: LabelBrickCellModel(text: "BRICK", configureCellBlock: LabelBrickCell.configure)),
+            ])
+        hideSectionButton = ButtonBrick(HideBrickViewController.Identifiers.HideSectionButton, backgroundColor: .brickGray1, title: titleForHideSectionButton) { [weak self] _ in
+            self?.hideSection()
+        }
+
+        self.collectionView?.backgroundColor = .brickBackground
+
+        let section = BrickSection(bricks: [
+            hiddenBrick,
+            hideBrickButton,
+            hiddenSection,
+            hideSectionButton
+            ], inset: 10, edgeInsets: UIEdgeInsets(top: 20, left: 20, bottom: 20, right: 20))
+
+        self.setSection(section)
+    }
+
+    var titleForHideBrickButton: String {
+        return "\(hiddenBrick.isHidden ? "Show" : "Hide") Brick".uppercaseString
+    }
+
+    var titleForHideSectionButton: String {
+        return "\(hiddenSection.isHidden ? "Show" : "Hide") Section".uppercaseString
+    }
+
+    func hideBrick() {
+        hiddenBrick.isHidden = !hiddenBrick.isHidden
+        hideBrickButton.title = titleForHideBrickButton
+        brickCollectionView.invalidateVisibility()
+        reloadBricksWithIdentifiers([HideBrickViewController.Identifiers.HideBrickButton])
+    }
+
+    func hideSection() {
+        hiddenSection.isHidden = !hiddenSection.isHidden
+        hideSectionButton.title = titleForHideSectionButton
+        brickCollectionView.invalidateVisibility()
+        reloadBricksWithIdentifiers([HideBrickViewController.Identifiers.HideSectionButton])
+    }
+
+}
+

--- a/Example/Source/Navigation/NavigationDataSource.swift
+++ b/Example/Source/Navigation/NavigationDataSource.swift
@@ -114,6 +114,7 @@ class NavigationDataSource {
         InsertBrickViewController.self,
         ChangeNibBrickViewController.self,
         HideSectionsViewController.self,
+        IsHiddenBrickViewController.self,
         DynamicContentViewController.self,
         InvalidateHeightViewController.self,
         InteractiveAlignViewController.self,
@@ -126,6 +127,7 @@ class NavigationDataSource {
         InsertBrickViewController.self,
         ChangeNibBrickViewController.self,
         HideSectionsViewController.self,
+        IsHiddenBrickViewController.self,
         DynamicContentViewController.self,
         InvalidateHeightViewController.self,
         InteractiveAlignViewController.self

--- a/Source/Layout/BrickFlowLayout.swift
+++ b/Source/Layout/BrickFlowLayout.swift
@@ -418,9 +418,7 @@ extension BrickFlowLayout: BrickLayoutSectionDataSource {
     func prepareForSizeCalculation(for attributes: BrickLayoutAttributes, containedIn width: CGFloat, origin: CGPoint, invalidate: Bool, in section: BrickLayoutSection, updatedAttributes: OnAttributesUpdatedHandler?) {
         let indexPath = attributes.indexPath
 
-        if let hideBehaviorDataSource = self.hideBehaviorDataSource {
-            attributes.hidden = hideBehaviorDataSource.hideBehaviorDataSource(shouldHideItemAtIndexPath: attributes.indexPath, withIdentifier: attributes.identifier, inCollectionViewLayout: self)
-        }
+        attributes.hidden = shouldHideItemAtIndexPath(shouldHideItemAtIndexPath: attributes.indexPath, withIdentifier: attributes.identifier)
 
         if let sectionAttributes = section.sectionAttributes where sectionAttributes.hidden {
             attributes.hidden = true
@@ -589,19 +587,30 @@ extension BrickFlowLayout: BrickLayoutInvalidationProvider {
         }
     }
 
-    func applyHideBehavior(hideBehaviorDataSource: HideBehaviorDataSource, updatedAttributes: OnAttributesUpdatedHandler) {
+    func applyHideBehavior(updatedAttributes updatedAttributes: OnAttributesUpdatedHandler) {
         guard let firstSection = sections?[0] else {
             return
         }
 
-        applyHideBehaviorForSection(hideBehaviorDataSource, for: firstSection, updatedAttributes: updatedAttributes)
+        applyHideBehaviorForSection(for: firstSection, updatedAttributes: updatedAttributes)
     }
 
-    func applyHideBehaviorForSection(hideBehaviorDataSource: HideBehaviorDataSource, for section: BrickLayoutSection, updatedAttributes: OnAttributesUpdatedHandler) {
+    func shouldHideItemAtIndexPath(shouldHideItemAtIndexPath indexPath: NSIndexPath, withIdentifier identifier: String) -> Bool {
+        if _dataSource.brickLayout(self, isItemHiddenAtIndexPath: indexPath) {
+            return true
+        }
+
+        if let hideBehaviorDataSource = hideBehaviorDataSource {
+            return hideBehaviorDataSource.hideBehaviorDataSource(shouldHideItemAtIndexPath: indexPath, withIdentifier: identifier, inCollectionViewLayout: self)
+        }
+        return false
+    }
+
+    func applyHideBehaviorForSection(for section: BrickLayoutSection, updatedAttributes: OnAttributesUpdatedHandler) {
         let currentFrame = section.frame
 
         for attributes in section.attributes.values {
-            var shouldHide = hideBehaviorDataSource.hideBehaviorDataSource(shouldHideItemAtIndexPath: attributes.indexPath, withIdentifier: attributes.identifier, inCollectionViewLayout: self)
+            var shouldHide = shouldHideItemAtIndexPath(shouldHideItemAtIndexPath: attributes.indexPath, withIdentifier: attributes.identifier)
 
             // If the sectionAttributes are hidden, hide this attribute as well
             if let sectionAttributes = section.sectionAttributes where sectionAttributes.hidden {
@@ -618,7 +627,7 @@ extension BrickFlowLayout: BrickLayoutInvalidationProvider {
             switch type {
             case .Section(let sectionIndex):
                 if let brickSection = sections?[sectionIndex] {
-                    applyHideBehaviorForSection(hideBehaviorDataSource, for: brickSection, updatedAttributes: updatedAttributes)
+                    applyHideBehaviorForSection(for: brickSection, updatedAttributes: updatedAttributes)
                 }
             default: break
             }

--- a/Source/Layout/BrickLayout.swift
+++ b/Source/Layout/BrickLayout.swift
@@ -91,6 +91,7 @@ public protocol BrickLayoutDataSource: class {
     func brickLayout(layout: BrickLayout, identifierForIndexPath indexPath: NSIndexPath) -> String
     func brickLayout(layout: BrickLayout, indexPathForSection section: Int) -> NSIndexPath?
     func brickLayout(layout: BrickLayout, isEstimatedHeightForIndexPath indexPath: NSIndexPath) -> Bool
+    func brickLayout(layout: BrickLayout, isItemHiddenAtIndexPath indexPath: NSIndexPath) -> Bool
 }
 
 extension BrickLayoutDataSource {
@@ -109,6 +110,10 @@ extension BrickLayoutDataSource {
 
     public func brickLayout(layout: BrickLayout, alignmentForSection section: Int) -> BrickAlignment {
         return BrickAlignment(horizontal: .Left, vertical: .Top)
+    }
+
+    public func brickLayout(layout: BrickLayout, isItemHiddenAtIndexPath indexPath: NSIndexPath) -> Bool {
+        return false
     }
 
 }

--- a/Source/Layout/BrickLayoutInvalidationContext.swift
+++ b/Source/Layout/BrickLayoutInvalidationContext.swift
@@ -50,7 +50,7 @@ protocol BrickLayoutInvalidationProvider: class {
 
 extension BrickLayoutInvalidationContext {
     override var description: String {
-        return super.description + " type: \(type)"
+        return "BrickLayoutInvalidationContext of type: \(type)"
     }
 }
 

--- a/Source/Layout/BrickLayoutInvalidationContext.swift
+++ b/Source/Layout/BrickLayoutInvalidationContext.swift
@@ -35,7 +35,6 @@ enum BrickLayoutInvalidationContextType {
 protocol BrickLayoutInvalidationProvider: class {
     var behaviors: Set<BrickLayoutBehavior> { get set }
     var contentSize: CGSize { get }
-    var hideBehaviorDataSource: HideBehaviorDataSource? { get }
 
     func removeAllCachedSections()
     func calculateSections()
@@ -45,7 +44,7 @@ protocol BrickLayoutInvalidationProvider: class {
     func invalidateContent(updatedAttributes: OnAttributesUpdatedHandler)
     func registerUpdatedAttributes(attributes: BrickLayoutAttributes, oldFrame: CGRect?, fromBehaviors: Bool, updatedAttributes: OnAttributesUpdatedHandler)
     func updateNumberOfItemsInSection(section: Int, numberOfItems: Int, updatedAttributes: OnAttributesUpdatedHandler)
-    func applyHideBehavior(hideBehavior: HideBehaviorDataSource, updatedAttributes: OnAttributesUpdatedHandler)
+    func applyHideBehavior(updatedAttributes updatedAttributes: OnAttributesUpdatedHandler)
     func updateContentSize(contentSize: CGSize)
 }
 
@@ -143,10 +142,7 @@ class BrickLayoutInvalidationContext: UICollectionViewLayoutInvalidationContext 
     }
 
     func applyHideBehaviors(provider: BrickLayoutInvalidationProvider, updatedAttributes: OnAttributesUpdatedHandler) {
-        guard let hideBehaviorDataSource = provider.hideBehaviorDataSource else {
-            return
-        }
-        provider.applyHideBehavior(hideBehaviorDataSource, updatedAttributes: updatedAttributes)
+        provider.applyHideBehavior(updatedAttributes: updatedAttributes)
     }
 
     func invalidateSections(provider: BrickLayoutInvalidationProvider, layout: UICollectionViewLayout) {

--- a/Source/Models/BrickModels.swift
+++ b/Source/Models/BrickModels.swift
@@ -26,7 +26,11 @@ public class Brick: CustomStringConvertible {
     /// Passes string to BrickCell's accessibilityHint for UIAccessibility.  Defaults to nil
     public var accessibilityHint: String?
 
+    /// Size of the brick
     public var size: BrickSize
+
+    /// Indicates if the brick is hidden
+    public var isHidden: Bool = false
     
     /// Width dimension used to calculate the width. Defaults to .Ratio(ratio: 1)
     public var width: BrickDimension {

--- a/Source/ViewControllers/BrickCollectionView+BrickLayoutDataSource.swift
+++ b/Source/ViewControllers/BrickCollectionView+BrickLayoutDataSource.swift
@@ -22,6 +22,10 @@ extension BrickCollectionView: BrickLayoutDataSource {
         }
     }
 
+    public func brickLayout(layout: BrickLayout, isItemHiddenAtIndexPath indexPath: NSIndexPath) -> Bool {
+        return self.brick(at: indexPath).isHidden
+    }
+
     public func brickLayout(layout: BrickLayout, isEstimatedHeightForIndexPath indexPath: NSIndexPath) -> Bool {
         let brick = self.brick(at: indexPath)
         if brick is BrickSection {

--- a/Tests/Behaviors/HideLayoutBehaviorTests.swift
+++ b/Tests/Behaviors/HideLayoutBehaviorTests.swift
@@ -12,13 +12,19 @@ import XCTest
 class HideLayoutBehaviorTests: BrickFlowLayoutBaseTests {
 
     func testHideOneRowBehavior() {
-        let hideBehaviorDataSource = FixedHideBehaviorDataSource(indexPaths: [NSIndexPath(forItem: 1, inSection: 0)])
-        self.layout.hideBehaviorDataSource = hideBehaviorDataSource
+        let hideBehaviorDataSource = FixedHideBehaviorDataSource(indexPaths: [NSIndexPath(forItem: 1, inSection: 1)])
+        collectionView.layout.hideBehaviorDataSource = hideBehaviorDataSource
 
-        setDataSources(SectionsCollectionViewDataSource(sections: [2]), brickLayoutDataSource: SectionsLayoutDataSource(widthRatios: [[1, 1]], heights: [[100, 100]], types: [[.Brick, .Brick]]))
+        collectionView.setupSectionAndLayout(BrickSection("Section 1", bricks: [
+            DummyBrick(height: .Fixed(size: 100)),
+            DummyBrick(height: .Fixed(size: 100))
+            ]))
 
         let expectedResult = [
             0 : [
+                CGRect(x: 0, y: 0, width: 320, height: 100)
+            ],
+            1 : [
                 CGRect(x: 0, y: 0, width: 320, height: 100)
             ]
         ]
@@ -29,19 +35,23 @@ class HideLayoutBehaviorTests: BrickFlowLayoutBaseTests {
         XCTAssertEqual(layout.collectionViewContentSize(), CGSize(width: 320, height: 100))
 
         let indexPaths = attributes?.map { return $0.indexPath }
-        XCTAssertEqual(indexPaths?.count, 1)
-        XCTAssertEqual(indexPaths?.first, NSIndexPath(forItem: 0, inSection: 0))
+        XCTAssertEqual(indexPaths?.count, 2)
+        XCTAssertEqual(indexPaths?[0], NSIndexPath(forItem: 0, inSection: 0))
+        XCTAssertEqual(indexPaths?[1], NSIndexPath(forItem: 0, inSection: 1))
     }
 
     func testHideAllRowsBehavior() {
-        let hideBehavior = FixedHideBehaviorDataSource(indexPaths: [NSIndexPath(forItem: 0, inSection: 0), NSIndexPath(forItem: 1, inSection: 0)])
+        let hideBehavior = FixedHideBehaviorDataSource(indexPaths: [NSIndexPath(forItem: 0, inSection: 1), NSIndexPath(forItem: 1, inSection: 1)])
         self.layout.hideBehaviorDataSource = hideBehavior
 
-        setDataSources(SectionsCollectionViewDataSource(sections: [2]), brickLayoutDataSource: SectionsLayoutDataSource(widthRatios: [[1, 1]], heights: [[100, 100]], edgeInsets: [UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)], types: [[.Brick, .Brick]]))
+        collectionView.setupSectionAndLayout(BrickSection("Section 1", bricks: [
+            DummyBrick(height: .Fixed(size: 100)),
+            DummyBrick(height: .Fixed(size: 100))
+            ], edgeInsets: UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)))
 
         let expectedResult: [Int: [CGRect]] = [:]
 
-        let attributes = layout.layoutAttributesForElementsInRect(collectionViewFrame)
+        let attributes = collectionView.layout.layoutAttributesForElementsInRect(collectionViewFrame)
         XCTAssertNotNil(attributes)
         XCTAssertTrue(verifyAttributesToExpectedResult(attributes!, expectedResult: expectedResult))
         XCTAssertEqual(layout.collectionViewContentSize(), CGSize(width: 320, height: 0))
@@ -49,13 +59,21 @@ class HideLayoutBehaviorTests: BrickFlowLayoutBaseTests {
 
 
     func testHideOneSectionBehavior() {
-        let hideBehaviorDataSource = FixedHideBehaviorDataSource(indexPaths: [NSIndexPath(forItem: 1, inSection: 0)])
+        let hideBehaviorDataSource = FixedHideBehaviorDataSource(indexPaths: [NSIndexPath(forItem: 1, inSection: 1)])
         self.layout.hideBehaviorDataSource = hideBehaviorDataSource
 
-        setDataSources(SectionsCollectionViewDataSource(sections: [2,1]), brickLayoutDataSource: SectionsLayoutDataSource(widthRatios: [[1, 1], [1]], heights: [[100, 100], [100]], types: [[.Brick, .Section(sectionIndex: 1)], [.Brick]]))
+        collectionView.setupSectionAndLayout(BrickSection("Section 1", bricks: [
+            DummyBrick(height: .Fixed(size: 100)),
+            BrickSection(bricks: [
+                DummyBrick(height: .Fixed(size: 100))
+                ])
+            ]))
 
         let expectedResult = [
             0 : [
+                CGRect(x: 0, y: 0, width: 320, height: 100),
+            ],
+            1 : [
                 CGRect(x: 0, y: 0, width: 320, height: 100),
             ]
         ]
@@ -68,9 +86,125 @@ class HideLayoutBehaviorTests: BrickFlowLayoutBaseTests {
     }
 
     func testHideMultiSections() {
-        let brickView = BrickCollectionView(frame: CGRect(x: 0, y: 0, width: 320, height: 480))
-        brickView.registerBrickClass(DummyBrick.self)
+        let hideBehaviorDataSource = FixedHideBehaviorDataSource(indexPaths: [NSIndexPath(forItem: 0, inSection: 1)])
+        collectionView.layout.hideBehaviorDataSource = hideBehaviorDataSource
 
+        collectionView.setupSectionAndLayout(BrickSection("Section 1", bricks: [
+            BrickSection("Section 2", bricks: [
+                BrickSection("Section 3", bricks: [DummyBrick(height: .Fixed(size: 50))]),
+                BrickSection("Section 4", bricks: [DummyBrick(height: .Fixed(size: 50))]),
+                BrickSection("Section 5", bricks: [DummyBrick(height: .Fixed(size: 50))])
+                ])
+            ]))
+        
+        XCTAssertEqual(collectionView.visibleCells().count, 0)
+    }
+
+    func testHideOneRowBehaviorWithHidden() {
+        let section = BrickSection("Section 1", bricks: [
+            DummyBrick(height: .Fixed(size: 100)),
+            DummyBrick(height: .Fixed(size: 100))
+            ])
+        section.bricks[1].isHidden = true
+        collectionView.setupSectionAndLayout(section)
+
+        let expectedResult = [
+            0 : [
+                CGRect(x: 0, y: 0, width: 320, height: 100)
+            ],
+            1 : [
+                CGRect(x: 0, y: 0, width: 320, height: 100)
+            ]
+        ]
+
+        let attributes = layout.layoutAttributesForElementsInRect(collectionViewFrame)
+        XCTAssertNotNil(attributes)
+        XCTAssertTrue(verifyAttributesToExpectedResult(attributes!, expectedResult: expectedResult))
+        XCTAssertEqual(layout.collectionViewContentSize(), CGSize(width: 320, height: 100))
+
+        let indexPaths = attributes?.map { return $0.indexPath }
+        XCTAssertEqual(indexPaths?.count, 2)
+        XCTAssertEqual(indexPaths?[0], NSIndexPath(forItem: 0, inSection: 0))
+        XCTAssertEqual(indexPaths?[1], NSIndexPath(forItem: 0, inSection: 1))
+    }
+
+    func testHideOneRowBehaviorWithHiddenAfterLayout() {
+        let section = BrickSection("Section 1", bricks: [
+            DummyBrick(height: .Fixed(size: 100)),
+            DummyBrick(height: .Fixed(size: 100))
+            ])
+        collectionView.setupSectionAndLayout(section)
+
+        section.bricks[1].isHidden = true
+        collectionView.invalidateVisibility()
+        collectionView.layoutSubviews()
+
+        let expectedResult = [
+            0 : [
+                CGRect(x: 0, y: 0, width: 320, height: 100)
+            ],
+            1 : [
+                CGRect(x: 0, y: 0, width: 320, height: 100)
+            ]
+        ]
+
+        let attributes = layout.layoutAttributesForElementsInRect(collectionViewFrame)
+        XCTAssertNotNil(attributes)
+        XCTAssertTrue(verifyAttributesToExpectedResult(attributes!, expectedResult: expectedResult))
+        XCTAssertEqual(layout.collectionViewContentSize(), CGSize(width: 320, height: 100))
+
+        let indexPaths = attributes?.map { return $0.indexPath }
+        XCTAssertEqual(indexPaths?.count, 2)
+        XCTAssertEqual(indexPaths?[0], NSIndexPath(forItem: 0, inSection: 0))
+        XCTAssertEqual(indexPaths?[1], NSIndexPath(forItem: 0, inSection: 1))
+    }
+
+    func testHideAllRowsBehaviorWithHidden() {
+        let section = BrickSection("Section 1", bricks: [
+            DummyBrick(height: .Fixed(size: 100)),
+            DummyBrick(height: .Fixed(size: 100))
+            ], edgeInsets: UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10))
+        section.bricks[0].isHidden = true
+        section.bricks[1].isHidden = true
+        collectionView.setupSectionAndLayout(section)
+
+
+        let expectedResult: [Int: [CGRect]] = [:]
+
+        let attributes = collectionView.layout.layoutAttributesForElementsInRect(collectionViewFrame)
+        XCTAssertNotNil(attributes)
+        XCTAssertTrue(verifyAttributesToExpectedResult(attributes!, expectedResult: expectedResult))
+        XCTAssertEqual(layout.collectionViewContentSize(), CGSize(width: 320, height: 0))
+    }
+
+
+    func testHideOneSectionBehaviorWithHidden() {
+        let section = BrickSection("Section 1", bricks: [
+            DummyBrick(height: .Fixed(size: 100)),
+            BrickSection(bricks: [
+                DummyBrick(height: .Fixed(size: 100))
+                ])
+            ])
+        section.bricks[1].isHidden = true
+        collectionView.setupSectionAndLayout(section)
+
+        let expectedResult = [
+            0 : [
+                CGRect(x: 0, y: 0, width: 320, height: 100),
+            ],
+            1 : [
+                CGRect(x: 0, y: 0, width: 320, height: 100),
+            ]
+        ]
+
+        let attributes = layout.layoutAttributesForElementsInRect(collectionViewFrame)
+        XCTAssertNotNil(attributes)
+        XCTAssertTrue(verifyAttributesToExpectedResult(attributes!, expectedResult: expectedResult))
+        XCTAssertEqual(layout.collectionViewContentSize(), CGSize(width: 320, height: 100))
+
+    }
+
+    func testHideMultiSectionsWithHidden() {
         let section = BrickSection("Section 1", bricks: [
             BrickSection("Section 2", bricks: [
                 BrickSection("Section 3", bricks: [DummyBrick(height: .Fixed(size: 50))]),
@@ -78,13 +212,10 @@ class HideLayoutBehaviorTests: BrickFlowLayoutBaseTests {
                 BrickSection("Section 5", bricks: [DummyBrick(height: .Fixed(size: 50))])
                 ])
             ])
-        let hideBehaviorDataSource = FixedHideBehaviorDataSource(indexPaths: [NSIndexPath(forItem: 0, inSection: 1)])
-        brickView.layout.hideBehaviorDataSource = hideBehaviorDataSource
-
-        brickView.setSection(section)
-        brickView.layoutSubviews()
-
-        XCTAssertEqual(brickView.visibleCells().count, 0)
+        section.bricks[0].isHidden = true
+        collectionView.setupSectionAndLayout(section)
+        
+        XCTAssertEqual(collectionView.visibleCells().count, 0)
     }
 
 }

--- a/Tests/Layout/BrickInvalidationContextTests.swift
+++ b/Tests/Layout/BrickInvalidationContextTests.swift
@@ -905,6 +905,32 @@ class BrickInvalidationContextTests: XCTestCase {
         XCTAssertEqual(brickViewController.collectionViewLayout.collectionViewContentSize(), CGSize(width: width, height: 0))
     }
 
+    func testHideBrickBehaviorMultipleBrickNestedSectionsWithHidden() {
+        brickViewController.brickCollectionView.registerNib(UINib(nibName: "DummyBrick100", bundle: NSBundle(forClass: DummyBrick.self)), forBrickWithIdentifier: "Brick")
+
+        let section = BrickSection("Test Section", bricks: [
+            BrickSection("Section 1", bricks: [
+                DummyBrick("Brick"),
+                BrickSection("Section 2", bricks: [
+                    DummyBrick("Brick")
+                    ])
+                ]),
+            ])
+
+        brickViewController.setSection(section)
+        brickViewController.collectionView!.layoutSubviews()
+
+        section.bricks[0].isHidden = true
+        brickViewController.brickCollectionView.invalidateVisibility()
+
+        let expectedResult: [Int: [CGRect]] = [:]
+
+        let attributes = brickViewController.collectionViewLayout.layoutAttributesForElementsInRect(CGRect(origin: CGPoint.zero, size: CGSize(width: width, height: width * 2)))
+        XCTAssertNotNil(attributes)
+        XCTAssertTrue(verifyAttributesToExpectedResult(attributes!, expectedResult: expectedResult))
+        XCTAssertEqual(brickViewController.collectionViewLayout.collectionViewContentSize(), CGSize(width: width, height: 0))
+    }
+
     func testWrongCollectionView() {
         let context = BrickLayoutInvalidationContext(type: .UpdateVisibility)
         XCTAssertFalse(context.invalidateWithLayout(UICollectionViewFlowLayout()))

--- a/Tests/Layout/BrickInvalidationContextTests.swift
+++ b/Tests/Layout/BrickInvalidationContextTests.swift
@@ -21,6 +21,11 @@ class BrickInvalidationContextTests: XCTestCase {
         width = brickViewController.view.frame.width
     }
 
+    func testDescription() {
+        let context = BrickLayoutInvalidationContext(type: .Creation)
+        XCTAssertEqual(context.description, "BrickLayoutInvalidationContext of type: Creation")
+    }
+
     func testInvalidateHeightFirstAttribute() {
         brickViewController.brickCollectionView.registerBrickClass(DummyBrick.self)
 


### PR DESCRIPTION
Introduces the `isHidden` property on the `Brick`-class. This way, there is not always a need for a `hideBehaviorDataSource` if this is wanted. After the flag is changed, the `invalidateVisibility` still needs to be called on the `BrickCollectionView`

Fixes #93