### PR TITLE
Fixed invalidateRepeatCounts

### DIFF
--- a/Source/Bricks/Image/ImageBrick.swift
+++ b/Source/Bricks/Image/ImageBrick.swift
@@ -172,7 +172,7 @@ public class ImageBrickCell: GenericBrickCell, Bricklike, AsynchronousResizableC
         imageView.contentMode = dataSource.contentModeForImageBrickCell(self)
 
         if let image = dataSource.imageForImageBrickCell(self) {
-            if self.brick.size.height.isEstimate(in: self) {
+            if self.brick.size.height.isEstimate {
                 self.setRatioConstraint(for: image)
             }
             imageView.image = image
@@ -209,7 +209,7 @@ public class ImageBrickCell: GenericBrickCell, Bricklike, AsynchronousResizableC
     }
 
     private func resize(image image: UIImage) {
-        if self.brick.size.height.isEstimate(in: self) {
+        if self.brick.size.height.isEstimate {
             self.setRatioConstraint(for: image)
             self.sizeChangedHandler?(cell: self)
         }

--- a/Source/Cells/BrickCell.swift
+++ b/Source/Cells/BrickCell.swift
@@ -198,7 +198,8 @@ public class BrickCell: BaseBrickCell {
     }
 
     public override func preferredLayoutAttributesFittingAttributes(layoutAttributes: UICollectionViewLayoutAttributes) -> UICollectionViewLayoutAttributes {
-        guard self._brick.size.height.isEstimate(in: self) else {
+        guard self._brick.height.isEstimate else {
+            layoutAttributes.frame.size.height = self._brick.height.value(for: layoutAttributes.frame.width, startingAt: 0)
             return layoutAttributes
         }
 

--- a/Source/Layout/BrickLayoutSection.swift
+++ b/Source/Layout/BrickLayoutSection.swift
@@ -151,8 +151,9 @@ internal class BrickLayoutSection {
 
         if difference > 0 {
             self.numberOfItems = numberOfItems
-            updateAttributeIdentifiers()
-            createOrUpdateCells(from: attributes.count, invalidate: false, updatedAttributes: addedAttributes)
+            var startIndex = attributes.count
+            updateAttributeIdentifiers(&startIndex)
+            createOrUpdateCells(from: startIndex, invalidate: true, updatedAttributes: addedAttributes)
         } else {
             self.numberOfItems = numberOfItems
             while attributes.count > numberOfItems {
@@ -162,14 +163,23 @@ internal class BrickLayoutSection {
                 
                 attributes.removeValueForKey(lastIndex)
             }
-            updateAttributeIdentifiers()
-            createOrUpdateCells(from: attributes.count, invalidate: true, updatedAttributes: nil)
+            var startIndex = attributes.count
+            updateAttributeIdentifiers(&startIndex)
+            createOrUpdateCells(from: startIndex, invalidate: true, updatedAttributes: nil)
         }
     }
 
-    func updateAttributeIdentifiers() {
+    /// Update the identifiers for the attributes
+    ///
+    /// - Parameter targetStartIndex: The index that should start invalidating bricks
+    func updateAttributeIdentifiers(inout targetStartIndex: Int) {
         for (index, attribute) in attributes {
-            attribute.identifier = _dataSource.identifier(for: index, in: self)
+            let identifier = _dataSource.identifier(for: index, in: self)
+            if attribute.identifier != identifier {
+                targetStartIndex = min(index, targetStartIndex)
+                attribute.identifier = identifier
+                invalidateAttributes(attribute)
+            }
         }
     }
 

--- a/Source/Models/BrickDimension.swift
+++ b/Source/Models/BrickDimension.swift
@@ -8,22 +8,6 @@
 
 import Foundation
 
-extension UIView {
-    
-    var isPortrait: Bool {
-        return UIScreen.mainScreen().bounds.width <= UIScreen.mainScreen().bounds.height
-    }
-
-    var horizontalSizeClass: UIUserInterfaceSizeClass {
-        return UIScreen.mainScreen().traitCollection.horizontalSizeClass
-    }
-
-    var verticalSizeClass: UIUserInterfaceSizeClass {
-        return UIScreen.mainScreen().traitCollection.verticalSizeClass
-    }
-    
-}
-
 public struct BrickSize {
     public var width: BrickDimension
     public var height: BrickDimension
@@ -44,39 +28,38 @@ public indirect enum BrickDimension {
     case HorizontalSizeClass(regular: BrickDimension, compact: BrickDimension)
     case VerticalSizeClass(regular: BrickDimension, compact: BrickDimension)
 
-    public func isEstimate(in view: UIView) -> Bool {
-        switch self.dimension(in: view) {
+    public var isEstimate: Bool {
+        switch self.dimension {
         case .Auto(_): return true
         default: return false
         }
     }
 
-    func dimension(in view: UIView) -> BrickDimension {
+    var dimension: BrickDimension {
         switch self {
         case .Orientation(let landScape, let portrait):
-            let isPortrait: Bool = view.isPortrait
-            return (isPortrait ? portrait : landScape).dimension(in: view)
+            return (BrickDimension.isPortrait ? portrait : landScape).dimension
         case .HorizontalSizeClass(let regular, let compact):
-            let isRegular = view.horizontalSizeClass == .Regular
-            return (isRegular ? regular : compact).dimension(in: view)
+            let isRegular = BrickDimension.horizontalSizeClass == .Regular
+            return (isRegular ? regular : compact).dimension
         case .VerticalSizeClass(let regular, let compact):
-            let isRegular = view.verticalSizeClass == .Regular
-            return (isRegular ? regular : compact).dimension(in: view)
+            let isRegular = BrickDimension.verticalSizeClass == .Regular
+            return (isRegular ? regular : compact).dimension
         default: return self
         }
     }
 
-    func value(for otherDimension: CGFloat, startingAt origin: CGFloat, in view: UIView) -> CGFloat {
-        let actualDimension = dimension(in: view)
+    func value(for otherDimension: CGFloat, startingAt origin: CGFloat) -> CGFloat {
+        let actualDimension = dimension
 
         switch actualDimension {
-        case .Auto(let dimension): return dimension.value(for: otherDimension, startingAt: origin, in: view)
-        default: return BrickDimension._rawValue(for: otherDimension, startingAt: origin, in: view, with: actualDimension)
+        case .Auto(let dimension): return dimension.value(for: otherDimension, startingAt: origin)
+        default: return BrickDimension._rawValue(for: otherDimension, startingAt: origin, with: actualDimension)
         }
     }
 
     /// Function that gets the raw value of a BrickDimension. As of right now, only Ratio, Fixed and Fill are allowed
-    static func _rawValue(for otherDimension: CGFloat, startingAt origin: CGFloat, in view: UIView, with dimension: BrickDimension) -> CGFloat {
+    static func _rawValue(for otherDimension: CGFloat, startingAt origin: CGFloat, with dimension: BrickDimension) -> CGFloat {
         switch dimension {
         case .Ratio(let ratio): return ratio * otherDimension
         case .Fixed(let size): return size
@@ -89,6 +72,23 @@ public indirect enum BrickDimension {
         default: fatalError("Only Ratio, Fixed and Fill are allowed")
         }
     }
+
+}
+
+extension BrickDimension {
+
+    static var isPortrait: Bool {
+        return UIScreen.mainScreen().bounds.width <= UIScreen.mainScreen().bounds.height
+    }
+
+    static var horizontalSizeClass: UIUserInterfaceSizeClass {
+        return UIScreen.mainScreen().traitCollection.horizontalSizeClass
+    }
+
+    static var verticalSizeClass: UIUserInterfaceSizeClass {
+        return UIScreen.mainScreen().traitCollection.verticalSizeClass
+    }
+
 }
 
 extension BrickDimension: Equatable {

--- a/Source/ViewControllers/BrickCollectionView+BrickLayoutDataSource.swift
+++ b/Source/ViewControllers/BrickCollectionView+BrickLayoutDataSource.swift
@@ -14,11 +14,11 @@ extension BrickCollectionView: BrickLayoutDataSource {
         let inset = self.brickLayout(layout, insetForSection: indexPath.section)
         let widthDimension = self.brick(at: indexPath).size.width
 
-        let dimension = widthDimension.dimension(in: self)
+        let dimension = widthDimension.dimension
 
         switch dimension {
         case .Ratio(let ratio): return BrickUtils.calculateWidth(for: ratio, widthRatio: widthRatio, totalWidth: totalWidth, inset: inset)
-        default: return dimension.value(for: totalWidth, startingAt: origin, in: self)
+        default: return dimension.value(for: totalWidth, startingAt: origin)
         }
     }
 
@@ -32,7 +32,7 @@ extension BrickCollectionView: BrickLayoutDataSource {
             return false
         }
 
-        return brick.size.height.isEstimate(in: self)
+        return brick.size.height.isEstimate
     }
 
     public func brickLayout(layout: BrickLayout, estimatedHeightForItemAtIndexPath indexPath: NSIndexPath, containedInWidth width: CGFloat) -> CGFloat {
@@ -42,7 +42,7 @@ extension BrickCollectionView: BrickLayoutDataSource {
         }
 
         let heightDimension = brick.size.height
-        return heightDimension.value(for: width, startingAt: 0, in: self)
+        return heightDimension.value(for: width, startingAt: 0)
     }
 
     public func brickLayout(layout: BrickLayout, edgeInsetsForSection section: Int) -> UIEdgeInsets {

--- a/Tests/Interactive/InteractiveTests.swift
+++ b/Tests/Interactive/InteractiveTests.swift
@@ -617,5 +617,32 @@ class InteractiveTests: XCTestCase {
         let attributes = brickView.layout.layoutAttributesForItemAtIndexPath(NSIndexPath(forItem: 1, inSection: 1)) as? BrickLayoutAttributes
         XCTAssertEqual(attributes?.identifier, "Brick1")
     }
+
+    func testThatInvalidateRepeatCountsHasCorrectValues() {
+        continueAfterFailure = true
+
+        let repeatDataSource = FixedRepeatCountDataSource(repeatCountHash: ["Brick2": 1])
+        let section = BrickSection(bricks: [
+            LabelBrick("Brick1", height: .Fixed(size: 50), text: "Label 1"),
+            LabelBrick("Brick2", height: .Fixed(size: 10), text: "Label 2"),
+            LabelBrick("Brick3", height: .Fixed(size: 50), text: "Label 3"),
+            ])
+        section.repeatCountDataSource = repeatDataSource
+        brickView.setupSectionAndLayout(section)
+
+        repeatDataSource.repeatCountHash = ["Brick2": 3]
+        let expectation = expectationWithDescription("Wait for invalidateVisibility")
+        brickView.invalidateRepeatCounts(reloadAllSections: true) { (completed, insertedIndexPaths, deletedIndexPaths) in
+            expectation.fulfill()
+        }
+        waitForExpectationsWithTimeout(5, handler: nil)
+        brickView.layoutIfNeeded()
+
+        XCTAssertEqual(brickView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 1))?.frame.height, 50)
+        XCTAssertEqual(brickView.cellForItemAtIndexPath(NSIndexPath(forItem: 1, inSection: 1))?.frame.height, 10)
+        XCTAssertEqual(brickView.cellForItemAtIndexPath(NSIndexPath(forItem: 2, inSection: 1))?.frame.height, 10)
+        XCTAssertEqual(brickView.cellForItemAtIndexPath(NSIndexPath(forItem: 3, inSection: 1))?.frame.height, 10)
+        XCTAssertEqual(brickView.cellForItemAtIndexPath(NSIndexPath(forItem: 4, inSection: 1))?.frame.height, 50)
+    }
     
 }

--- a/Tests/Layout/BrickInvalidationContextTests.swift
+++ b/Tests/Layout/BrickInvalidationContextTests.swift
@@ -953,6 +953,7 @@ class BrickInvalidationContextTests: XCTestCase {
         brickViewController.setSection(section)
         brickViewController.collectionView!.layoutSubviews()
 
+        section.bricks[1].height = .Fixed(size: 100)
         let context = BrickLayoutInvalidationContext(type: .UpdateHeight(indexPath: NSIndexPath(forItem: 1, inSection: 1), newHeight: 100))
         brickViewController.layout.invalidateLayoutWithContext(context)
         brickViewController.brickCollectionView.layoutIfNeeded()
@@ -991,6 +992,7 @@ class BrickInvalidationContextTests: XCTestCase {
 
         brickViewController.brickCollectionView.setupSectionAndLayout(section)
 
+        section.bricks[0].height = .Fixed(size: 100)
         var context = BrickLayoutInvalidationContext(type: .UpdateHeight(indexPath: NSIndexPath(forItem: 0, inSection: 1), newHeight: 100))
         brickViewController.layout.invalidateLayoutWithContext(context)
         XCTAssertEqual(context.contentOffsetAdjustment, CGPoint(x: 0, y: 0))
@@ -998,6 +1000,7 @@ class BrickInvalidationContextTests: XCTestCase {
         XCTAssertEqual(brickViewController.brickCollectionView.contentOffset.y, 0)
 
         brickViewController.brickCollectionView.contentOffset.y = 100
+        section.bricks[0].height = .Fixed(size: 150)
         context = BrickLayoutInvalidationContext(type: .UpdateHeight(indexPath: NSIndexPath(forItem: 0, inSection: 1), newHeight: 150))
         brickViewController.layout.invalidateLayoutWithContext(context)
         XCTAssertEqual(context.contentOffsetAdjustment, CGPoint(x: 0, y: 50))
@@ -1006,6 +1009,7 @@ class BrickInvalidationContextTests: XCTestCase {
             XCTAssertEqual(brickViewController.brickCollectionView.contentOffset.y, 150)
         #endif
 
+        section.bricks[0].height = .Fixed(size: 100)
         context = BrickLayoutInvalidationContext(type: .UpdateHeight(indexPath: NSIndexPath(forItem: 0, inSection: 1), newHeight: 100))
         brickViewController.layout.invalidateLayoutWithContext(context)
         XCTAssertEqual(context.contentOffsetAdjustment, CGPoint(x: 0, y: -50))

--- a/Tests/Models/BrickDimensionTests.swift
+++ b/Tests/Models/BrickDimensionTests.swift
@@ -28,105 +28,105 @@ class BrickDimensionTests: XCTestCase {
     func testViewPortrait() {
         setScreenPortrait(true)
 
-        XCTAssertNotNil(view.horizontalSizeClass)
-        XCTAssertNotNil(view.verticalSizeClass)
-        XCTAssertTrue(view.isPortrait)
+        XCTAssertNotNil(BrickDimension.horizontalSizeClass)
+        XCTAssertNotNil(BrickDimension.verticalSizeClass)
+        XCTAssertTrue(BrickDimension.isPortrait)
     }
 
     func testViewLandscape() {
         setScreenPortrait(false)
 
-        XCTAssertFalse(view.isPortrait)
+        XCTAssertFalse(BrickDimension.isPortrait)
     }
 
     func testViewSquare() {
         StubScreen.bounds.size = CGSize(width: 320, height: 320)
 
-        XCTAssertTrue(view.isPortrait)
+        XCTAssertTrue(BrickDimension.isPortrait)
     }
 
     func testFixed() {
         let fixed = BrickDimension.Fixed(size: 50)
-        XCTAssertEqual(fixed.value(for: 1000, startingAt: 0, in: UIView()), 50)
-        XCTAssertEqual(fixed.dimension(in: UIView()), fixed)
-        XCTAssertFalse(fixed.isEstimate(in: UIView()))
+        XCTAssertEqual(fixed.value(for: 1000, startingAt: 0), 50)
+        XCTAssertEqual(fixed.dimension, fixed)
+        XCTAssertFalse(fixed.isEstimate)
         XCTAssertEqual(fixed, BrickDimension.Fixed(size: 50))
         XCTAssertNotEqual(fixed, BrickDimension.Fixed(size: 100))
     }
 
     func testRatio() {
         let ratio = BrickDimension.Ratio(ratio: 0.5)
-        XCTAssertEqual(ratio.value(for: 1000, startingAt: 0, in: UIView()), 500)
-        XCTAssertEqual(ratio.dimension(in: UIView()), ratio)
-        XCTAssertFalse(ratio.isEstimate(in: UIView()))
+        XCTAssertEqual(ratio.value(for: 1000, startingAt: 0), 500)
+        XCTAssertEqual(ratio.dimension, ratio)
+        XCTAssertFalse(ratio.isEstimate)
         XCTAssertEqual(ratio, BrickDimension.Ratio(ratio: 0.5))
         XCTAssertNotEqual(ratio, BrickDimension.Fixed(size: 100))
     }
 
     func testFill() {
         let ratio = BrickDimension.Fill
-        XCTAssertEqual(ratio.value(for: 1000, startingAt: 0, in: UIView()), 1000)
-        XCTAssertEqual(ratio.dimension(in: UIView()), ratio)
-        XCTAssertFalse(ratio.isEstimate(in: UIView()))
+        XCTAssertEqual(ratio.value(for: 1000, startingAt: 0), 1000)
+        XCTAssertEqual(ratio.dimension, ratio)
+        XCTAssertFalse(ratio.isEstimate)
         XCTAssertEqual(ratio, BrickDimension.Fill)
         XCTAssertNotEqual(ratio, BrickDimension.Fixed(size: 100))
     }
 
     func testFillWithStartingOrigin() {
         let ratio = BrickDimension.Fill
-        XCTAssertEqual(ratio.value(for: 1000, startingAt: 500, in: UIView()), 500)
-        XCTAssertEqual(ratio.dimension(in: UIView()), ratio)
-        XCTAssertFalse(ratio.isEstimate(in: UIView()))
+        XCTAssertEqual(ratio.value(for: 1000, startingAt: 500), 500)
+        XCTAssertEqual(ratio.dimension, ratio)
+        XCTAssertFalse(ratio.isEstimate)
         XCTAssertEqual(ratio, BrickDimension.Fill)
         XCTAssertNotEqual(ratio, BrickDimension.Fixed(size: 100))
     }
 
     func testFillWithStartingOriginThatIsTooBig() {
         let ratio = BrickDimension.Fill
-        XCTAssertEqual(ratio.value(for: 1000, startingAt: 1001, in: UIView()), 1000)
-        XCTAssertEqual(ratio.dimension(in: UIView()), ratio)
-        XCTAssertFalse(ratio.isEstimate(in: UIView()))
+        XCTAssertEqual(ratio.value(for: 1000, startingAt: 1001), 1000)
+        XCTAssertEqual(ratio.dimension, ratio)
+        XCTAssertFalse(ratio.isEstimate)
         XCTAssertEqual(ratio, BrickDimension.Fill)
         XCTAssertNotEqual(ratio, BrickDimension.Fixed(size: 100))
     }
 
     func testAutoFixed() {
         let autoFixed = BrickDimension.Auto(estimate: BrickDimension.Fixed(size: 50))
-        XCTAssertEqual(autoFixed.value(for: 1000, startingAt: 0, in: UIView()), 50)
-        XCTAssertEqual(autoFixed.dimension(in: UIView()), autoFixed)
-        XCTAssertTrue(autoFixed.isEstimate(in: UIView()))
+        XCTAssertEqual(autoFixed.value(for: 1000, startingAt: 0), 50)
+        XCTAssertEqual(autoFixed.dimension, autoFixed)
+        XCTAssertTrue(autoFixed.isEstimate)
         XCTAssertEqual(autoFixed, BrickDimension.Auto(estimate: BrickDimension.Fixed(size: 50)))
     }
 
     func testAutoRatio() {
         let autoRatio = BrickDimension.Auto(estimate: BrickDimension.Ratio(ratio: 0.5))
-        XCTAssertEqual(autoRatio.value(for: 1000, startingAt: 0, in: UIView()), 500)
-        XCTAssertEqual(autoRatio.dimension(in: UIView()), autoRatio)
-        XCTAssertTrue(autoRatio.isEstimate(in: UIView()))
+        XCTAssertEqual(autoRatio.value(for: 1000, startingAt: 0), 500)
+        XCTAssertEqual(autoRatio.dimension, autoRatio)
+        XCTAssertTrue(autoRatio.isEstimate)
         XCTAssertEqual(autoRatio, BrickDimension.Auto(estimate: BrickDimension.Ratio(ratio: 0.5)))
     }
 
     func testOrientationPortrait() {
         setupScreen(isPortrait: true, horizontalSizeClass: .Compact, verticalSizeClass: .Compact)
         let orientation = BrickDimension.Orientation(landscape: BrickDimension.Fixed(size: 100), portrait: BrickDimension.Fixed(size: 50))
-        XCTAssertEqual(orientation.value(for: 1000, startingAt: 0, in: view), 50)
-        XCTAssertEqual(orientation.dimension(in: view), BrickDimension.Fixed(size: 50))
+        XCTAssertEqual(orientation.value(for: 1000, startingAt: 0), 50)
+        XCTAssertEqual(orientation.dimension, BrickDimension.Fixed(size: 50))
         XCTAssertEqual(orientation, BrickDimension.Orientation(landscape: BrickDimension.Fixed(size: 100), portrait: BrickDimension.Fixed(size: 50)))
     }
 
     func testOrientationLandscape() {
         setupScreen(isPortrait: false, horizontalSizeClass: .Compact, verticalSizeClass: .Compact)
         let orientation = BrickDimension.Orientation(landscape: BrickDimension.Fixed(size: 100), portrait: BrickDimension.Fixed(size: 50))
-        XCTAssertEqual(orientation.value(for: 1000, startingAt: 0, in: view), 100)
-        XCTAssertEqual(orientation.dimension(in: view), BrickDimension.Fixed(size: 100))
+        XCTAssertEqual(orientation.value(for: 1000, startingAt: 0), 100)
+        XCTAssertEqual(orientation.dimension, BrickDimension.Fixed(size: 100))
         XCTAssertEqual(orientation, BrickDimension.Orientation(landscape: BrickDimension.Fixed(size: 100), portrait: BrickDimension.Fixed(size: 50)))
     }
 
     func testHorizontalSizeClassCompact() {
         setupScreen(isPortrait: true, horizontalSizeClass: .Compact, verticalSizeClass: .Regular)
         let sizeClass = BrickDimension.HorizontalSizeClass(regular: BrickDimension.Fixed(size: 100), compact: BrickDimension.Fixed(size: 50))
-        XCTAssertEqual(sizeClass.value(for: 1000, startingAt: 0, in: view), 50)
-        XCTAssertEqual(sizeClass.dimension(in: view), BrickDimension.Fixed(size: 50))
+        XCTAssertEqual(sizeClass.value(for: 1000, startingAt: 0), 50)
+        XCTAssertEqual(sizeClass.dimension, BrickDimension.Fixed(size: 50))
         XCTAssertEqual(sizeClass, BrickDimension.HorizontalSizeClass(regular: BrickDimension.Fixed(size: 100), compact: BrickDimension.Fixed(size: 50)))
 
     }
@@ -134,24 +134,24 @@ class BrickDimensionTests: XCTestCase {
     func testHorizontalSizeClassRegular() {
         setupScreen(isPortrait: true, horizontalSizeClass: .Regular, verticalSizeClass: .Compact)
         let sizeClass = BrickDimension.HorizontalSizeClass(regular: BrickDimension.Fixed(size: 100), compact: BrickDimension.Fixed(size: 50))
-        XCTAssertEqual(sizeClass.value(for: 1000, startingAt: 0, in: view), 100)
-        XCTAssertEqual(sizeClass.dimension(in: view), BrickDimension.Fixed(size: 100))
+        XCTAssertEqual(sizeClass.value(for: 1000, startingAt: 0), 100)
+        XCTAssertEqual(sizeClass.dimension, BrickDimension.Fixed(size: 100))
         XCTAssertEqual(sizeClass, BrickDimension.HorizontalSizeClass(regular: BrickDimension.Fixed(size: 100), compact: BrickDimension.Fixed(size: 50)))
     }
 
     func testVerticalSizeClassCompact() {
         setupScreen(isPortrait: true, horizontalSizeClass: .Regular, verticalSizeClass: .Compact)
         let sizeClass = BrickDimension.VerticalSizeClass(regular: BrickDimension.Fixed(size: 100), compact: BrickDimension.Fixed(size: 50))
-        XCTAssertEqual(sizeClass.value(for: 1000, startingAt: 0, in: view), 50)
-        XCTAssertEqual(sizeClass.dimension(in: view), BrickDimension.Fixed(size: 50))
+        XCTAssertEqual(sizeClass.value(for: 1000, startingAt: 0), 50)
+        XCTAssertEqual(sizeClass.dimension, BrickDimension.Fixed(size: 50))
         XCTAssertEqual(sizeClass, BrickDimension.VerticalSizeClass(regular: BrickDimension.Fixed(size: 100), compact: BrickDimension.Fixed(size: 50)))
     }
 
     func testVerticalSizeClassRegular() {
         setupScreen(isPortrait: true, horizontalSizeClass: .Compact, verticalSizeClass: .Regular)
         let sizeClass = BrickDimension.VerticalSizeClass(regular: BrickDimension.Fixed(size: 100), compact: BrickDimension.Fixed(size: 50))
-        XCTAssertEqual(sizeClass.value(for: 1000, startingAt: 0, in: view), 100)
-        XCTAssertEqual(sizeClass.dimension(in: view), BrickDimension.Fixed(size: 100))
+        XCTAssertEqual(sizeClass.value(for: 1000, startingAt: 0), 100)
+        XCTAssertEqual(sizeClass.dimension, BrickDimension.Fixed(size: 100))
         XCTAssertEqual(sizeClass, BrickDimension.VerticalSizeClass(regular: BrickDimension.Fixed(size: 100), compact: BrickDimension.Fixed(size: 50)))
     }
 
@@ -164,9 +164,9 @@ class BrickDimensionTests: XCTestCase {
                 regular: .Auto(estimate: .Fixed(size: 100)),
                 compact: .Auto(estimate: .Fixed(size: 50))
             ))
-        XCTAssertEqual(nested.value(for: 1000, startingAt: 0, in: view), 50)
-        XCTAssertEqual(nested.dimension(in: view), BrickDimension.Auto(estimate: BrickDimension.Fixed(size: 50)))
-        XCTAssertTrue(nested.isEstimate(in: view))
+        XCTAssertEqual(nested.value(for: 1000, startingAt: 0), 50)
+        XCTAssertEqual(nested.dimension, BrickDimension.Auto(estimate: BrickDimension.Fixed(size: 50)))
+        XCTAssertTrue(nested.isEstimate)
         XCTAssertEqual(nested, BrickDimension.Orientation(
             landscape: .Fixed(size: 50),
             portrait: .HorizontalSizeClass(
@@ -178,7 +178,7 @@ class BrickDimensionTests: XCTestCase {
     func testRawValue() {
         expectFatalError { 
             let auto = BrickDimension.Auto(estimate: .Fixed(size: 30))
-            BrickDimension._rawValue(for: 100, startingAt: 0, in: UIView(), with: auto)
+            BrickDimension._rawValue(for: 100, startingAt: 0, with: auto)
         }
     }
 


### PR DESCRIPTION
This issue came along when invalidating a repeat count of a section with multiple bricks. The logic assumed that the repeat count was set for simular bricks and only for appending. This fix will now check if the attributes have the same identifiers. And if not, the invalidation of the cells will start with the first attribute that has a different identifier

Fixes #101