### PR TITLE
Fix severe memory leak when using async resizable cells

### DIFF
--- a/Source/ViewControllers/BrickCollectionView.swift
+++ b/Source/ViewControllers/BrickCollectionView.swift
@@ -531,13 +531,14 @@ extension BrickCollectionView: UICollectionViewDataSource {
 
         if let brickCell = cell as? BrickCell {
             if var resizable = brickCell as? AsynchronousResizableCell {
-                resizable.sizeChangedHandler = { [weak collectionView] cell in
-                    let height = cell.heightForBrickView(withWidth: brickCell.frame.width)
-                    if let brickCollectionView = collectionView as? BrickCollectionView {
-                        brickCollectionView.performBatchUpdates({
-                            brickCollectionView.layout.updateHeight(indexPath, newHeight: height)
-                            }, completion: nil)
+                resizable.sizeChangedHandler = { [weak brickCollectionView] resizedCell in
+                    guard let brickCollectionView = brickCollectionView else {
+                        return
                     }
+                    let height = resizedCell.heightForBrickView(withWidth: resizedCell.frame.width)
+                    brickCollectionView.performBatchUpdates({
+                        brickCollectionView.layout.updateHeight(indexPath, newHeight: height)
+                        }, completion: nil)
                 }
             }
 

--- a/Tests/Cells/AsynchronousResizableBrick.swift
+++ b/Tests/Cells/AsynchronousResizableBrick.swift
@@ -10,10 +10,8 @@ import UIKit
 import BrickKit
 
 class AsynchronousResizableBrick: Brick {
-
     var didChangeSizeCallBack: (() -> Void)?
     var newHeight: CGFloat = 200
-
 }
 
 class AsynchronousResizableBrickCell: BrickCell, Bricklike, AsynchronousResizableCell {
@@ -35,5 +33,20 @@ class AsynchronousResizableBrickCell: BrickCell, Bricklike, AsynchronousResizabl
         sizeChangedHandler?(cell: self)
         brick.didChangeSizeCallBack?()
     }
+}
 
+class DeinitNotifyingAsyncBrickCell: BrickCell, Bricklike, AsynchronousResizableCell {
+    typealias BrickType = DeinitNotifyingAsyncBrick
+
+    var sizeChangedHandler: CellSizeChangedHandler?
+
+    deinit {
+        NSNotificationCenter.defaultCenter().postNotificationName("DeinitNotifyingAsyncBrickCell.deinit", object: nil)
+    }
+}
+
+class DeinitNotifyingAsyncBrick: Brick {
+    override class var cellClass: UICollectionViewCell.Type? {
+        return DeinitNotifyingAsyncBrickCell.self
+    }
 }

--- a/Tests/ViewControllers/BrickCollectionViewTests.swift
+++ b/Tests/ViewControllers/BrickCollectionViewTests.swift
@@ -16,7 +16,9 @@ class BrickCollectionViewTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        brickView = BrickCollectionView(frame: CGRect(x: 0, y: 0, width: 320, height: 480))
+        autoreleasepool {
+            self.brickView = BrickCollectionView(frame: CGRect(x: 0, y: 0, width: 320, height: 480))
+        }
     }
 
     func testSetWrongCollectionViewLayout() {
@@ -683,5 +685,15 @@ class BrickCollectionViewTests: XCTestCase {
         XCTAssertEqual(innerSection.brickCollectionView, brickView)
     }
 
+    func testThatBrickCollectionViewDoesNotCreateARetainCycleWithAsyncrhonousResizableCells() {
+        expectationForNotification("DeinitNotifyingAsyncBrickCell.deinit", object: nil, handler: nil)
 
+        autoreleasepool {
+            let brick = DeinitNotifyingAsyncBrick(size: BrickSize(width: .Fill, height: .Fill))
+            brickView.setupSingleBrickAndLayout(brick)
+            brickView = nil
+        }
+
+        waitForExpectationsWithTimeout(5, handler: nil)
+    }
 }


### PR DESCRIPTION
Previously, the sizeChangedHandler callback set on resizable cells in BrickCollectionView was accidentally capturing a collection cell reference from outside the closure and causing a retain cycle, even though the cell was passed into the closure as an argument. This change resolves that issue so that the argument is referenced instead of any captured variables.

This also includes a test to ensure that the collection cell is deallocated properly if the brick collection view that owns it is also deallocated. I needed to make a new test async cell since the existing one uses an NSTimer which interferes with the deinitialization in ways I don't fully understand.

I recommend releasing a new version of BrickKit as soon as this is merged since this can leak a lot of memory, especially if the async brick is a collection brick containing child collection views/cells.