### PR TITLE
SectionAttributes weren’t updated

### DIFF
--- a/Source/Layout/BrickLayoutSection.swift
+++ b/Source/Layout/BrickLayoutSection.swift
@@ -651,6 +651,8 @@ internal class BrickLayoutSection {
         let height: CGFloat
 
         // Prepare the datasource that size calculation will happen
+        brickAttributes.frame.origin = cellOrigin
+        brickAttributes.originalFrame = brickAttributes.frame
         dataSource.prepareForSizeCalculation(for: brickAttributes, containedIn: width, origin: cellOrigin, invalidate: invalidate, in: self, updatedAttributes: updatedAttributes)
 
         if let brickFrame = oldOriginalFrame where !invalidate {

--- a/Tests/Layout/BrickLayoutSectionTests.swift
+++ b/Tests/Layout/BrickLayoutSectionTests.swift
@@ -375,6 +375,56 @@ class BrickLayoutSectionTests: XCTestCase {
         section.invalidate(at: 0, updatedAttributes: nil)
     }
 
+    func testThatSetOriginUpdatesAttributesOrigin() {
+        // setup ipad sized collection view
+        let brickView: BrickCollectionView = BrickCollectionView(frame: CGRect(x: 0, y: 0, width: 768, height: 968))
 
+        // setup brick section
+        let topLeftHalf = BrickSection(width: .Ratio(ratio: 0.5), bricks: [
+            DummyBrick("BrickLeft", height: .Fixed(size: 300)),
+            ])
+        topLeftHalf.isHidden = true
+
+        // Fixed width section
+        let fixedWidthSection: Brick = BrickSection("fixedWidthSection", bricks: [
+            DummyBrick("BrickFixed1", width: .Fixed(size: 89), height: .Fixed(size: 40)),
+            DummyBrick("BrickFixed2", width: .Fixed(size: 200), height: .Fixed(size: 40))
+            ])
+
+        let nonFixedWidthSection: Brick = BrickSection("nonFixedWidthSection", bricks: [
+            DummyBrick("BrickNonFixed1", height: .Fixed(size: 41)),
+        ])
+
+        let topRightHalf = BrickSection("topRightHalf", width: .Ratio(ratio: 0.5), bricks: [
+            fixedWidthSection,
+            nonFixedWidthSection,
+            ])
+
+        let brickSection = BrickSection("topSection", bricks: [
+            topLeftHalf,
+            topRightHalf
+            ], edgeInsets: UIEdgeInsetsMake(0, 8, 0, 8))
+
+        // hide left half and layout brick section
+        brickView.setupSectionAndLayout(brickSection)
+
+        let topRightHalfIndexPath = brickView.indexPathsForBricksWithIdentifier(topRightHalf.identifier).first!
+        let topRightHalfCell = brickView.cellForItemAtIndexPath(topRightHalfIndexPath)
+        XCTAssertEqual(topRightHalfCell?.frame.width, 376)
+
+        // show left half
+        topLeftHalf.isHidden = false
+        brickView.invalidateVisibility()
+        brickView.layoutIfNeeded()
+
+        let fixedWidthSectionIndexPath = brickView.indexPathsForBricksWithIdentifier(fixedWidthSection.identifier).first!
+        let fixedWidthSectionCell = brickView.cellForItemAtIndexPath(fixedWidthSectionIndexPath)
+        XCTAssertEqual(fixedWidthSectionCell?.frame.origin.x, 384)
+
+        let nonFixedWidthSectionIndexPath = brickView.indexPathsForBricksWithIdentifier(nonFixedWidthSection.identifier).first!
+        let nonFixedWidthSectionCell = brickView.cellForItemAtIndexPath(nonFixedWidthSectionIndexPath)
+        XCTAssertEqual(nonFixedWidthSectionCell?.frame.origin.x, 384)
+
+}
 
 }

--- a/Tests/ViewControllers/BrickViewControllerTests.swift
+++ b/Tests/ViewControllers/BrickViewControllerTests.swift
@@ -19,6 +19,7 @@ class BrickViewControllerTests: XCTestCase {
 
         continueAfterFailure = false
         brickViewController = BrickViewController()
+        brickViewController.view.frame = CGRect(x: 0, y: 0, width: 320, height: 480)
         width = brickViewController.view.frame.width
     }
 


### PR DESCRIPTION
When recalculating the origin of a section, the origin of the sectionAttributes weren’t set upfront

Fixes #104