### PR TITLE
Removed a line that modified an attribute’s height

### DIFF
--- a/Source/Cells/BrickCell.swift
+++ b/Source/Cells/BrickCell.swift
@@ -199,7 +199,6 @@ public class BrickCell: BaseBrickCell {
 
     public override func preferredLayoutAttributesFittingAttributes(layoutAttributes: UICollectionViewLayoutAttributes) -> UICollectionViewLayoutAttributes {
         guard self._brick.height.isEstimate else {
-            layoutAttributes.frame.size.height = self._brick.height.value(for: layoutAttributes.frame.width, startingAt: 0)
             return layoutAttributes
         }
 

--- a/Tests/Behaviors/CoverFlowLayoutBehaviorTests.swift
+++ b/Tests/Behaviors/CoverFlowLayoutBehaviorTests.swift
@@ -110,5 +110,23 @@ class CoverFlowLayoutBehaviorTests: XCTestCase {
     func testIfContentSizeIsCalculatedCorrectly() {
         XCTAssertEqual(brickView.contentSize, CGSize(width: 2000, height: 50))
     }
+
+    func testIfLayoutAttributesAreCalculatedCorrectly() {
+        brickView.contentOffset.x = brickView.frame.width / 6
+        brickView.layoutIfNeeded()
+
+        let cell1 = brickView.cellForItemAtIndexPath(NSIndexPath(forItem: 1, inSection: 1)) as! BrickCell
+
+        guard let layoutAttributes = brickView.layout.layoutAttributesForItemAtIndexPath(NSIndexPath(forItem: 1, inSection: 1)) else {
+            XCTFail("layoutAttributes should not be nil")
+            return
+        }
+        let heightBefore = layoutAttributes.frame.size.height
+
+        let newLayout = cell1.preferredLayoutAttributesFittingAttributes(layoutAttributes)
+        let heightAfter = newLayout.frame.size.height
+
+        XCTAssertTrue(heightBefore == heightAfter)
+    }
 }
 


### PR DESCRIPTION
before returning the preferred layout attributes. This line broke cover flow and was causing stack overflows in some cases.