### PR TITLE
Collection bricks with a fixed height would infinitely resize.

### DIFF
--- a/Source/Bricks/Collection/CollectionBrick.swift
+++ b/Source/Bricks/Collection/CollectionBrick.swift
@@ -145,6 +145,10 @@ open class CollectionBrickCell: BrickCell, Bricklike, AsynchronousResizableCell 
             return super.preferredLayoutAttributesFitting(layoutAttributes)
         }
         
+        guard self._brick.size.height.isEstimate(in: self) else {
+            return layoutAttributes
+        }
+        
         isCalculatingHeight = true
 
         brickCollectionView.frame = layoutAttributes.bounds

--- a/Tests/Bricks/CollectionBrickTests.swift
+++ b/Tests/Bricks/CollectionBrickTests.swift
@@ -43,6 +43,7 @@ class CollectionBrickTests: XCTestCase {
             ])
         brickView.setSection(section)
         brickView.layoutSubviews()
+        brickView.layoutIfNeeded()
 
         let cell1 = brickView.cellForItem(at: IndexPath(item: 0, section: 1)) as? CollectionBrickCell
         XCTAssertEqual(cell1?.brickCollectionView.visibleCells.count, 2)


### PR DESCRIPTION
This is an issue when you have an outer collection brick with a fixed height, and an inner collection brick with an automatic height. When scrolling the outer collection brick, the inner collection brick will keep resizing itself because the outer collection brick is also resizing itself. This merge makes it so that if a collection brick has a fixed height, it will not try to resize itself.

Fixes #109