### PR TITLE
-Addresses an issue when using multiple BrickCollectionViews as Cells…

### DIFF
--- a/Source/Bricks/Collection/CollectionBrick.swift
+++ b/Source/Bricks/Collection/CollectionBrick.swift
@@ -109,7 +109,7 @@ public class CollectionBrickCellModel: CollectionBrickCellDataSource {
 public class CollectionBrickCell: BrickCell, Bricklike, AsynchronousResizableCell {
     public typealias BrickType = CollectionBrick
 
-    public var sizeChangedHandler: CellSizeChangedHandler?
+    public weak var resizeDelegate: AsynchronousResizableDelegate?
 
     /// Flag that indicates if the CollectionBrick is calculating its height
     // This is introduced because otherwise the sizeChangedHandler might get called while calculating.
@@ -208,8 +208,9 @@ extension CollectionBrickCell: BrickLayoutDelegate {
             return
         }
 
-        sizeChangedHandler?(cell: self)
-        brickCollectionView.layoutSubviews()
+        self.resizeDelegate?.performResize(self, completion: { [weak self] (completed: Bool) in
+            self?.brickCollectionView.layoutSubviews()
+        })
     }
 
 }

--- a/Source/Bricks/Image/ImageBrick.swift
+++ b/Source/Bricks/Image/ImageBrick.swift
@@ -140,7 +140,7 @@ public class ImageURLBrickModel: ImageBrickDataSource {
 public class ImageBrickCell: GenericBrickCell, Bricklike, AsynchronousResizableCell, ImageDownloaderCell {
     public typealias BrickType = ImageBrick
 
-    public var sizeChangedHandler: CellSizeChangedHandler?
+    public weak var resizeDelegate: AsynchronousResizableDelegate?
 
     public weak var imageDownloader: ImageDownloader?
 
@@ -211,7 +211,7 @@ public class ImageBrickCell: GenericBrickCell, Bricklike, AsynchronousResizableC
     private func resize(image image: UIImage) {
         if self.brick.size.height.isEstimate {
             self.setRatioConstraint(for: image)
-            self.sizeChangedHandler?(cell: self)
+            self.resizeDelegate?.performResize(self, completion: nil)
         }
     }
 

--- a/Source/Cells/BrickCell.swift
+++ b/Source/Cells/BrickCell.swift
@@ -10,10 +10,12 @@ import UIKit
 
 // Mark: - Resizeable cells
 
-public typealias CellSizeChangedHandler = ((cell: BrickCell) -> Void)
+public protocol AsynchronousResizableCell: class  {
+    weak var resizeDelegate: AsynchronousResizableDelegate? { get set }
+}
 
-public protocol AsynchronousResizableCell {
-    var sizeChangedHandler: CellSizeChangedHandler? { get set }
+public protocol AsynchronousResizableDelegate: class {
+    func performResize(cell: BrickCell, completion: ((Bool) -> Void)?)
 }
 
 public protocol ImageDownloaderCell {

--- a/Tests/Cells/AsynchronousResizableBrick.swift
+++ b/Tests/Cells/AsynchronousResizableBrick.swift
@@ -17,8 +17,7 @@ class AsynchronousResizableBrick: Brick {
 class AsynchronousResizableBrickCell: BrickCell, Bricklike, AsynchronousResizableCell {
     typealias BrickType = AsynchronousResizableBrick
 
-    var sizeChangedHandler: CellSizeChangedHandler?
-
+    weak var resizeDelegate: AsynchronousResizableDelegate?
     @IBOutlet weak var heightConstraint: NSLayoutConstraint!
     var timer: NSTimer?
 
@@ -30,15 +29,21 @@ class AsynchronousResizableBrickCell: BrickCell, Bricklike, AsynchronousResizabl
 
     func fireTimer() {
         self.heightConstraint.constant = brick.newHeight
-        sizeChangedHandler?(cell: self)
-        brick.didChangeSizeCallBack?()
+        self.resizeDelegate?.performResize(self, completion: { [weak self] (completed: Bool) in
+            self?.brick.didChangeSizeCallBack?()
+        })
     }
 }
 
 class DeinitNotifyingAsyncBrickCell: BrickCell, Bricklike, AsynchronousResizableCell {
     typealias BrickType = DeinitNotifyingAsyncBrick
 
-    var sizeChangedHandler: CellSizeChangedHandler?
+    weak var resizeDelegate: AsynchronousResizableDelegate?
+
+    override func updateContent() {
+        super.updateContent()
+        self.resizeDelegate?.performResize(self, completion: nil)
+    }
 
     deinit {
         NSNotificationCenter.defaultCenter().postNotificationName("DeinitNotifyingAsyncBrickCell.deinit", object: nil)


### PR DESCRIPTION
… within a BrickCollectionView and then scrolling fast.

    
    -The collectionView which is performing the batchUpdates on the AsynchronousResizableCell gets deallocated inflight, and causes a crash.  This change holds a strong reference to the cell and unowned reference to the collectionView, so that it completes updating before dealloc.