### PR TITLE
Addresses an issue when using multiple BrickCollectionViews as Cells …

### DIFF
--- a/Source/Bricks/Collection/CollectionBrick.swift
+++ b/Source/Bricks/Collection/CollectionBrick.swift
@@ -109,7 +109,7 @@ open class CollectionBrickCellModel: CollectionBrickCellDataSource {
 open class CollectionBrickCell: BrickCell, Bricklike, AsynchronousResizableCell {
     public typealias BrickType = CollectionBrick
 
-    open var sizeChangedHandler: CellSizeChangedHandler?
+    public weak var resizeDelegate: AsynchronousResizableDelegate?
 
     /// Flag that indicates if the CollectionBrick is calculating its height
     // This is introduced because otherwise the sizeChangedHandler might get called while calculating.
@@ -207,8 +207,9 @@ extension CollectionBrickCell: BrickLayoutDelegate {
             return
         }
 
-        sizeChangedHandler?(self)
-        brickCollectionView.layoutSubviews()
+        self.resizeDelegate?.performResize(cell: self, completion: { [weak self] (completed: Bool) in
+            self?.brickCollectionView.layoutSubviews()
+        })
     }
 
 }

--- a/Source/Bricks/Collection/CollectionBrick.swift
+++ b/Source/Bricks/Collection/CollectionBrick.swift
@@ -207,7 +207,7 @@ extension CollectionBrickCell: BrickLayoutDelegate {
             return
         }
 
-        self.resizeDelegate?.performResize(cell: self, completion: { [weak self] (completed: Bool) in
+        self.resizeDelegate?.performResize(cell: self, completion: { [weak self] _ in
             self?.brickCollectionView.layoutSubviews()
         })
     }

--- a/Source/Bricks/Image/ImageBrick.swift
+++ b/Source/Bricks/Image/ImageBrick.swift
@@ -142,7 +142,7 @@ open class ImageURLBrickModel: ImageBrickDataSource {
 open class ImageBrickCell: GenericBrickCell, Bricklike, AsynchronousResizableCell, ImageDownloaderCell {
     public typealias BrickType = ImageBrick
 
-    open var sizeChangedHandler: CellSizeChangedHandler?
+    public weak var resizeDelegate: AsynchronousResizableDelegate?
 
     open weak var imageDownloader: ImageDownloader?
 
@@ -213,7 +213,7 @@ open class ImageBrickCell: GenericBrickCell, Bricklike, AsynchronousResizableCel
     fileprivate func resize(image: UIImage) {
         if self.brick.size.height.isEstimate(in: self) {
             self.setRatioConstraint(for: image)
-            self.sizeChangedHandler?(self)
+            self.resizeDelegate?.performResize(cell: self, completion: nil)
         }
     }
 

--- a/Source/Cells/BrickCell.swift
+++ b/Source/Cells/BrickCell.swift
@@ -10,10 +10,12 @@ import UIKit
 
 // Mark: - Resizeable cells
 
-public typealias CellSizeChangedHandler = ((_ cell: BrickCell) -> Void)
+public protocol AsynchronousResizableCell: class  {
+    weak var resizeDelegate: AsynchronousResizableDelegate? { get set }
+}
 
-public protocol AsynchronousResizableCell {
-    var sizeChangedHandler: CellSizeChangedHandler? { get set }
+public protocol AsynchronousResizableDelegate: class {
+    func performResize(cell: BrickCell, completion: ((Bool) -> Void)?)
 }
 
 public protocol ImageDownloaderCell {

--- a/Source/ViewControllers/BrickCollectionView.swift
+++ b/Source/ViewControllers/BrickCollectionView.swift
@@ -205,7 +205,7 @@ open class BrickCollectionView: UICollectionView {
         _ = self.invalidateRepeatCountsWithoutPerformBatchUpdates(reloadSections)
         self.performBatchUpdates({
             if reloadSections {
-                self.reloadSections(IndexSet(integersIn: NSMakeRange(0, self.numberOfSections).toRange()!))
+                self.reloadSections(IndexSet(integersIn: 0..<self.numberOfSections))
             }
             self.collectionViewLayout.invalidateLayout(with: BrickLayoutInvalidationContext(type: .invalidate))
             }, completion: { completed in

--- a/Tests/Cells/AsynchronousResizableBrick.swift
+++ b/Tests/Cells/AsynchronousResizableBrick.swift
@@ -29,7 +29,7 @@ class AsynchronousResizableBrickCell: BrickCell, Bricklike, AsynchronousResizabl
 
     func fireTimer() {
         self.heightConstraint.constant = brick.newHeight
-        self.resizeDelegate?.performResize(cell: self, completion: { [weak self] (completed: Bool) in
+        self.resizeDelegate?.performResize(cell: self, completion: { [weak self] (_: Bool) in
             self?.brick.didChangeSizeCallBack?()
         })
     }

--- a/Tests/Cells/AsynchronousResizableBrick.swift
+++ b/Tests/Cells/AsynchronousResizableBrick.swift
@@ -19,8 +19,7 @@ class AsynchronousResizableBrick: Brick {
 class AsynchronousResizableBrickCell: BrickCell, Bricklike, AsynchronousResizableCell {
     typealias BrickType = AsynchronousResizableBrick
 
-    var sizeChangedHandler: CellSizeChangedHandler?
-
+    weak var resizeDelegate: AsynchronousResizableDelegate?
     @IBOutlet weak var heightConstraint: NSLayoutConstraint!
     var timer: Timer?
 
@@ -32,8 +31,30 @@ class AsynchronousResizableBrickCell: BrickCell, Bricklike, AsynchronousResizabl
 
     func fireTimer() {
         self.heightConstraint.constant = brick.newHeight
-        sizeChangedHandler?(self)
-        brick.didChangeSizeCallBack?()
+        self.resizeDelegate?.performResize(cell: self, completion: { [weak self] (completed: Bool) in
+            self?.brick.didChangeSizeCallBack?()
+        })
+    }
+}
+
+class DeinitNotifyingAsyncBrickCell: BrickCell, Bricklike, AsynchronousResizableCell {
+
+    typealias BrickType = DeinitNotifyingAsyncBrick
+
+    weak var resizeDelegate: AsynchronousResizableDelegate?
+
+    override func updateContent() {
+        super.updateContent()
+        self.resizeDelegate?.performResize(cell: self, completion: nil)
     }
 
+    deinit {
+        NotificationCenter.default.post(name: NSNotification.Name(rawValue: "DeinitNotifyingAsyncBrickCell.deinit"), object: nil)
+    }
+}
+
+class DeinitNotifyingAsyncBrick: Brick {
+    override class var cellClass: UICollectionViewCell.Type? {
+        return DeinitNotifyingAsyncBrickCell.self
+    }
 }


### PR DESCRIPTION
…within a BrickCollectionView and then scrolling fast.

    
The collectionView which is performing the batchUpdates on the AsynchronousResizableCell gets deallocated inflight, and causes a crash.  This changes it from using having the cell hold a closure, to using a delegate callback to the collectionView which then performs the batch update.