### PR TITLE
Varadic range support

### DIFF
--- a/Example/Source/Examples/Layout/SizeClassesBrickViewController.swift
+++ b/Example/Source/Examples/Layout/SizeClassesBrickViewController.swift
@@ -43,7 +43,7 @@ class SizeClassesBrickViewController: BrickViewController, HasTitle {
                                                       (dimension: .ratio(ratio: 1/4), minimumLength: CGFloat(700)),
                                                       (dimension: .ratio(ratio: 1/5), minimumLength: CGFloat(1100)),
                                                       (dimension: .ratio(ratio: 1/6), minimumLength: CGFloat(1300))]
-        let regularDimensionRange : BrickDimension = .dimensionRange(range: BrickRangeDimention(minimum: .ratio(ratio: 1.0), additionalRangePairs: additionalRangePairs))
+        let regularDimensionRange : BrickDimension = .dimensionRange(range: BrickRangeDimension(minimum: .ratio(ratio: 1.0), additionalRangePairs: additionalRangePairs))
         let horizontalWidth: BrickDimension = .horizontalSizeClass(regular: regularDimensionRange, compact: .ratio(ratio: 0.5))
         
         variableWidthBrick = SizeClassBrick("Variable", width: horizontalWidth, backgroundColor: .brickSection)

--- a/Example/Source/Examples/Layout/SizeClassesBrickViewController.swift
+++ b/Example/Source/Examples/Layout/SizeClassesBrickViewController.swift
@@ -38,12 +38,12 @@ class SizeClassesBrickViewController: BrickViewController, HasTitle {
         sizeClassHalf = SizeClassBrick("Half", width: .ratio(ratio: 0.5), backgroundColor: .brickSection)
         sizeClassHalf.color = .brickGray5
         
-        let additionalRangePairs : [RangeDimensionPair] = [(dimension: .ratio(ratio: 1/2), minimumLength: CGFloat(300)),
-                                                      (dimension: .ratio(ratio: 1/3), minimumLength: CGFloat(580)),
-                                                      (dimension: .ratio(ratio: 1/4), minimumLength: CGFloat(700)),
-                                                      (dimension: .ratio(ratio: 1/5), minimumLength: CGFloat(1100)),
-                                                      (dimension: .ratio(ratio: 1/6), minimumLength: CGFloat(1300))]
-        let regularDimensionRange : BrickDimension = .dimensionRange(minimum: .ratio(ratio: 1.0), additionalRangePairs: additionalRangePairs)
+        let additionalRangePairs : [RangeDimensionPair] = [(dimension: .ratio(ratio: 1/2), minimumSize: CGFloat(300)),
+                                                      (dimension: .ratio(ratio: 1/3), minimumSize: CGFloat(580)),
+                                                      (dimension: .ratio(ratio: 1/4), minimumSize: CGFloat(700)),
+                                                      (dimension: .ratio(ratio: 1/5), minimumSize: CGFloat(1100)),
+                                                      (dimension: .ratio(ratio: 1/6), minimumSize: CGFloat(1300))]
+        let regularDimensionRange : BrickDimension = .dimensionRange(default: .ratio(ratio: 1.0), additionalRangePairs: additionalRangePairs)
         let horizontalWidth: BrickDimension = .horizontalSizeClass(regular: regularDimensionRange, compact: .ratio(ratio: 0.5))
         
         variableWidthBrick = SizeClassBrick("Variable", width: horizontalWidth, backgroundColor: .brickSection)

--- a/Example/Source/Examples/Layout/SizeClassesBrickViewController.swift
+++ b/Example/Source/Examples/Layout/SizeClassesBrickViewController.swift
@@ -21,6 +21,7 @@ class SizeClassesBrickViewController: BrickViewController, HasTitle {
 
     var sizeClassFull: SizeClassBrick!
     var sizeClassHalf: SizeClassBrick!
+    var variableWidthBrick: SizeClassBrick!
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -36,10 +37,28 @@ class SizeClassesBrickViewController: BrickViewController, HasTitle {
 
         sizeClassHalf = SizeClassBrick("Half", width: .ratio(ratio: 0.5), backgroundColor: .brickSection)
         sizeClassHalf.color = .brickGray5
-
-        let section = BrickSection("Size Classes", bricks: [
+        
+        let additionalRangePairs : [RangeDimensionPair] = [(dimension: .ratio(ratio: 1/2), minimumLength: CGFloat(300)),
+                                                      (dimension: .ratio(ratio: 1/3), minimumLength: CGFloat(580)),
+                                                      (dimension: .ratio(ratio: 1/4), minimumLength: CGFloat(700)),
+                                                      (dimension: .ratio(ratio: 1/5), minimumLength: CGFloat(1100)),
+                                                      (dimension: .ratio(ratio: 1/6), minimumLength: CGFloat(1300))]
+        let regularDimensionRange : BrickDimension = .dimensionRange(range: BrickRangeDimention(minimum: .ratio(ratio: 1.0), additionalRangePairs: additionalRangePairs))
+        let horizontalWidth: BrickDimension = .horizontalSizeClass(regular: regularDimensionRange, compact: .ratio(ratio: 0.5))
+        
+        variableWidthBrick = SizeClassBrick("Variable", width: horizontalWidth, backgroundColor: .brickSection)
+        variableWidthBrick.repeatCount = 10
+        variableWidthBrick.text = "Variable Width"
+        variableWidthBrick.color = .brickGray4
+        let ratioSection = BrickSection("Ratio", bricks: [
             sizeClassFull,
             sizeClassHalf
+        ], inset: 10, edgeInsets: UIEdgeInsets(top: 20, left: 20, bottom: 20, right: 20))
+        
+        
+        let section = BrickSection("Size Classes", bricks: [
+            ratioSection,
+            variableWidthBrick
             ], inset: 10, edgeInsets: UIEdgeInsets(top: 20, left: 20, bottom: 20, right: 20))
 
         self.setSection(section)

--- a/Example/Source/Examples/Layout/SizeClassesBrickViewController.swift
+++ b/Example/Source/Examples/Layout/SizeClassesBrickViewController.swift
@@ -43,7 +43,7 @@ class SizeClassesBrickViewController: BrickViewController, HasTitle {
                                                       (dimension: .ratio(ratio: 1/4), minimumLength: CGFloat(700)),
                                                       (dimension: .ratio(ratio: 1/5), minimumLength: CGFloat(1100)),
                                                       (dimension: .ratio(ratio: 1/6), minimumLength: CGFloat(1300))]
-        let regularDimensionRange : BrickDimension = .dimensionRange(range: BrickRangeDimension(minimum: .ratio(ratio: 1.0), additionalRangePairs: additionalRangePairs))
+        let regularDimensionRange : BrickDimension = .dimensionRange(minimum: .ratio(ratio: 1.0), additionalRangePairs: additionalRangePairs)
         let horizontalWidth: BrickDimension = .horizontalSizeClass(regular: regularDimensionRange, compact: .ratio(ratio: 0.5))
         
         variableWidthBrick = SizeClassBrick("Variable", width: horizontalWidth, backgroundColor: .brickSection)

--- a/Source/Bricks/Collection/CollectionBrick.swift
+++ b/Source/Bricks/Collection/CollectionBrick.swift
@@ -145,11 +145,11 @@ open class CollectionBrickCell: BrickCell, Bricklike, AsynchronousResizableCell 
             return super.preferredLayoutAttributesFitting(layoutAttributes)
         }
         
-        guard self._brick.size.height.isEstimate else {
+        guard self._brick.size.height.isEstimate(withValue: nil) else {
             return layoutAttributes
         }
         
-        guard self._brick.height.isEstimate else {
+        guard self._brick.height.isEstimate(withValue: nil) else {
             layoutAttributes.frame.size.height = self._brick.height.value(for: layoutAttributes.frame.width, startingAt: 0)
             return layoutAttributes
         }

--- a/Source/Bricks/Image/ImageBrick.swift
+++ b/Source/Bricks/Image/ImageBrick.swift
@@ -174,7 +174,7 @@ open class ImageBrickCell: GenericBrickCell, Bricklike, AsynchronousResizableCel
         imageView.contentMode = dataSource.contentModeForImageBrickCell(self)
 
         if let image = dataSource.imageForImageBrickCell(self) {
-            if self.brick.size.height.isEstimate {
+            if self.brick.size.height.isEstimate(withValue: nil) {
                 self.setRatioConstraint(for: image)
             }
             imageView.image = image
@@ -211,7 +211,7 @@ open class ImageBrickCell: GenericBrickCell, Bricklike, AsynchronousResizableCel
 
 
     fileprivate func resize(image: UIImage) {
-        if self.brick.size.height.isEstimate {
+        if self.brick.size.height.isEstimate(withValue: nil) {
             self.setRatioConstraint(for: image)
             self.resizeDelegate?.performResize(cell: self, completion: nil)
         }

--- a/Source/Cells/BrickCell.swift
+++ b/Source/Cells/BrickCell.swift
@@ -200,7 +200,7 @@ open class BrickCell: BaseBrickCell {
     }
 
     open override func preferredLayoutAttributesFitting(_ layoutAttributes: UICollectionViewLayoutAttributes) -> UICollectionViewLayoutAttributes {
-        guard self._brick.height.isEstimate else {
+        guard self._brick.height.isEstimate(withValue: nil) else {
             return layoutAttributes
         }
 

--- a/Source/Models/BrickDimension.swift
+++ b/Source/Models/BrickDimension.swift
@@ -27,7 +27,9 @@ public struct BrickRangeDimention {
     public init(minimum dimension: BrickDimension, additionalRangePairs: [RangeDimensionPair]?) {
         dimensionPairs = [(dimension, 0)]
         if let additionalRangePairs = additionalRangePairs {
-            dimensionPairs.append(contentsOf: additionalRangePairs)
+            dimensionPairs.append(contentsOf: additionalRangePairs.sorted {
+                $0.minimumLength < $1.minimumLength
+            })
         }
     }
     

--- a/Source/Models/BrickDimension.swift
+++ b/Source/Models/BrickDimension.swift
@@ -115,7 +115,7 @@ public enum BrickDimension {
     }
 
     func value(for otherDimension: CGFloat, startingAt origin: CGFloat) -> CGFloat {
-        let actualDimension: BrickDimension = dimension(withValue: otherDimension)
+        let actualDimension = dimension(withValue: otherDimension)
         
         switch actualDimension {
         case .auto(let dimension): return dimension.value(for: otherDimension, startingAt: origin)

--- a/Source/ViewControllers/BrickCollectionView+BrickLayoutDataSource.swift
+++ b/Source/ViewControllers/BrickCollectionView+BrickLayoutDataSource.swift
@@ -14,7 +14,7 @@ extension BrickCollectionView: BrickLayoutDataSource {
         let inset = self.brickLayout(layout, insetFor: indexPath.section)
         let widthDimension = self.brick(at: indexPath).size.width
 
-        let dimension = widthDimension.dimension
+        let dimension = widthDimension.dimension(withValue: totalWidth)
 
         switch dimension {
         case .ratio(let ratio): return BrickUtils.calculateWidth(for: ratio, widthRatio: widthRatio, totalWidth: totalWidth, inset: inset)

--- a/Source/ViewControllers/BrickCollectionView+BrickLayoutDataSource.swift
+++ b/Source/ViewControllers/BrickCollectionView+BrickLayoutDataSource.swift
@@ -32,7 +32,7 @@ extension BrickCollectionView: BrickLayoutDataSource {
             return false
         }
 
-        return brick.size.height.isEstimate
+        return brick.size.height.isEstimate(withValue: nil)
     }
 
     public func brickLayout(_ layout: BrickLayout, estimatedHeightForItemAt indexPath: IndexPath, containedIn width: CGFloat) -> CGFloat {

--- a/Tests/Models/BrickDimensionTests.swift
+++ b/Tests/Models/BrickDimensionTests.swift
@@ -175,12 +175,12 @@ class BrickDimensionTests: XCTestCase {
             )))
     }
     
-    func testBrickRangeDimention() {
+    func testBrickRangeDimension() {
         setupScreen(isPortrait: true, horizontalSizeClass: .compact, verticalSizeClass: .regular)
         
         let additionalRangePairs: [RangeDimensionPair] = [(dimension: .ratio(ratio: 0.25), minimumLength: CGFloat(700)),
                                                           (dimension: .ratio(ratio: 0.5), minimumLength: CGFloat(350))] // Intentionally out of order
-        let regularDimensionRange : BrickDimension = .dimensionRange(range: BrickRangeDimention(minimum: .ratio(ratio: 1.0), additionalRangePairs: additionalRangePairs))
+        let regularDimensionRange : BrickDimension = .dimensionRange(minimum: .ratio(ratio: 1.0), additionalRangePairs: additionalRangePairs)
         XCTAssertEqual(regularDimensionRange.value(for: 320, startingAt: 0), 320)
         setupScreen(isPortrait: true, horizontalSizeClass: .regular, verticalSizeClass: .regular)
         XCTAssertEqual(regularDimensionRange.value(for: 350, startingAt: 0), 175)
@@ -190,15 +190,15 @@ class BrickDimensionTests: XCTestCase {
     
     func testVariableDimensionEquality() {
         let additionalRangePairs1: [RangeDimensionPair] = [(dimension: .ratio(ratio: 1/2), minimumLength: CGFloat(350))]
-        let dimensionRange1: BrickDimension = .dimensionRange(range: BrickRangeDimention(minimum: .ratio(ratio: 1.0), additionalRangePairs: additionalRangePairs1))
+        let dimensionRange1: BrickDimension = .dimensionRange(minimum: .ratio(ratio: 1.0), additionalRangePairs: additionalRangePairs1)
         let additionalRangePairs2: [RangeDimensionPair] = [(dimension: .ratio(ratio: 0.5), minimumLength: CGFloat(350))]
-        let dimensionRange2: BrickDimension = .dimensionRange(range: BrickRangeDimention(minimum: .ratio(ratio: 0.5 + 0.5), additionalRangePairs: additionalRangePairs2))
+        let dimensionRange2: BrickDimension = .dimensionRange(minimum: .ratio(ratio: 0.5 + 0.5), additionalRangePairs: additionalRangePairs2)
         let additionalRangePairs3: [RangeDimensionPair] = [(dimension: .ratio(ratio: 1/3), minimumLength: CGFloat(350))]
-        let dimensionRange3: BrickDimension = .dimensionRange(range: BrickRangeDimention(minimum: .ratio(ratio: 1.0), additionalRangePairs: additionalRangePairs3))
+        let dimensionRange3: BrickDimension = .dimensionRange(minimum: .ratio(ratio: 1.0), additionalRangePairs: additionalRangePairs3)
         let additionalRangePairs4: [RangeDimensionPair] = [(dimension: .ratio(ratio: 1/2), minimumLength: CGFloat(350))]
-        let dimensionRange4: BrickDimension = .dimensionRange(range: BrickRangeDimention(minimum: .ratio(ratio: 1.5), additionalRangePairs: additionalRangePairs4))
+        let dimensionRange4: BrickDimension = .dimensionRange(minimum: .ratio(ratio: 1.5), additionalRangePairs: additionalRangePairs4)
         let additionalRangePairs5: [RangeDimensionPair] = [(dimension: .ratio(ratio: 1/2), minimumLength: CGFloat(350)), (dimension: .ratio(ratio: 1/3), minimumLength: CGFloat(500))]
-        let dimensionRange5: BrickDimension = .dimensionRange(range: BrickRangeDimention(minimum: .ratio(ratio: 1.5), additionalRangePairs: additionalRangePairs5))
+        let dimensionRange5: BrickDimension = .dimensionRange(minimum: .ratio(ratio: 1.5), additionalRangePairs: additionalRangePairs5)
         XCTAssertEqual(dimensionRange1, dimensionRange2)
         XCTAssertNotEqual(dimensionRange1, dimensionRange3)
         XCTAssertNotEqual(dimensionRange1, dimensionRange4)
@@ -212,14 +212,14 @@ class BrickDimensionTests: XCTestCase {
         XCTAssertTrue(dimensionPair2 == dimensionPair1)
         XCTAssertFalse(dimensionPair1 == dimensionPair3)
         XCTAssertFalse(dimensionPair1 == dimensionPair4)
-        XCTAssertFalse(almostEqualRelative(A: 350, B: 350.001)) // Needed for code coverage completeness.
+        XCTAssertFalse(almostEqualRelative(first: 350, second: 350.001)) // Needed for code coverage completeness.
     }
     
-    func testNestedBrickRangeDimention() {
+    func testNestedBrickRangeDimension() {
         let additionalRangePairs: [RangeDimensionPair] = [(dimension: .ratio(ratio: 1/2), minimumLength: CGFloat(350)),
                                                      (dimension: .ratio(ratio: 0.25), minimumLength: CGFloat(700))]
-        let nestedDimensionRange : BrickDimension = .dimensionRange(range: BrickRangeDimention(minimum: .ratio(ratio: 0.5), additionalRangePairs: additionalRangePairs))
-        let regularDimensionRange : BrickDimension = .dimensionRange(range: BrickRangeDimention(minimum: nestedDimensionRange, additionalRangePairs: nil))
+        let nestedDimensionRange : BrickDimension = .dimensionRange(minimum: .ratio(ratio: 0.5), additionalRangePairs: additionalRangePairs)
+        let regularDimensionRange : BrickDimension = .dimensionRange(minimum: nestedDimensionRange, additionalRangePairs: nil)
         XCTAssertEqual(regularDimensionRange.dimension(withValue: 200).value(for: 200, startingAt: 0), 100);
         XCTAssertEqual(regularDimensionRange.dimension(withValue: 400).value(for: 400, startingAt: 0), 200);
         XCTAssertEqual(regularDimensionRange.dimension(withValue: 800).value(for: 800, startingAt: 0), 200);

--- a/Tests/Models/BrickDimensionTests.swift
+++ b/Tests/Models/BrickDimensionTests.swift
@@ -48,7 +48,7 @@ class BrickDimensionTests: XCTestCase {
     func testFixed() {
         let fixed = BrickDimension.fixed(size: 50)
         XCTAssertEqual(fixed.value(for: 1000, startingAt: 0), 50)
-        XCTAssertEqual(fixed.dimension, fixed)
+        XCTAssertEqual(fixed.dimension(withValue: nil), fixed)
         XCTAssertFalse(fixed.isEstimate)
         XCTAssertEqual(fixed, BrickDimension.fixed(size: 50))
         XCTAssertNotEqual(fixed, BrickDimension.fixed(size: 100))
@@ -57,7 +57,7 @@ class BrickDimensionTests: XCTestCase {
     func testRatio() {
         let ratio = BrickDimension.ratio(ratio: 0.5)
         XCTAssertEqual(ratio.value(for: 1000, startingAt: 0), 500)
-        XCTAssertEqual(ratio.dimension, ratio)
+        XCTAssertEqual(ratio.dimension(withValue: nil), ratio)
         XCTAssertFalse(ratio.isEstimate)
         XCTAssertEqual(ratio, BrickDimension.ratio(ratio: 0.5))
         XCTAssertNotEqual(ratio, BrickDimension.fixed(size: 100))
@@ -66,7 +66,7 @@ class BrickDimensionTests: XCTestCase {
     func testFill() {
         let ratio = BrickDimension.fill
         XCTAssertEqual(ratio.value(for: 1000, startingAt: 0), 1000)
-        XCTAssertEqual(ratio.dimension, ratio)
+        XCTAssertEqual(ratio.dimension(withValue: nil), ratio)
         XCTAssertFalse(ratio.isEstimate)
         XCTAssertEqual(ratio, BrickDimension.fill)
         XCTAssertNotEqual(ratio, BrickDimension.fixed(size: 100))
@@ -75,7 +75,7 @@ class BrickDimensionTests: XCTestCase {
     func testFillWithStartingOrigin() {
         let ratio = BrickDimension.fill
         XCTAssertEqual(ratio.value(for: 1000, startingAt: 500), 500)
-        XCTAssertEqual(ratio.dimension, ratio)
+        XCTAssertEqual(ratio.dimension(withValue: nil), ratio)
         XCTAssertFalse(ratio.isEstimate)
         XCTAssertEqual(ratio, BrickDimension.fill)
         XCTAssertNotEqual(ratio, BrickDimension.fixed(size: 100))
@@ -84,7 +84,7 @@ class BrickDimensionTests: XCTestCase {
     func testFillWithStartingOriginThatIsTooBig() {
         let ratio = BrickDimension.fill
         XCTAssertEqual(ratio.value(for: 1000, startingAt: 1001), 1000)
-        XCTAssertEqual(ratio.dimension, ratio)
+        XCTAssertEqual(ratio.dimension(withValue: nil), ratio)
         XCTAssertFalse(ratio.isEstimate)
         XCTAssertEqual(ratio, BrickDimension.fill)
         XCTAssertNotEqual(ratio, BrickDimension.fixed(size: 100))
@@ -93,7 +93,7 @@ class BrickDimensionTests: XCTestCase {
     func testAutoFixed() {
         let autoFixed = BrickDimension.auto(estimate: BrickDimension.fixed(size: 50))
         XCTAssertEqual(autoFixed.value(for: 1000, startingAt: 0), 50)
-        XCTAssertEqual(autoFixed.dimension, autoFixed)
+        XCTAssertEqual(autoFixed.dimension(withValue: nil), autoFixed)
         XCTAssertTrue(autoFixed.isEstimate)
         XCTAssertEqual(autoFixed, BrickDimension.auto(estimate: BrickDimension.fixed(size: 50)))
     }
@@ -101,7 +101,7 @@ class BrickDimensionTests: XCTestCase {
     func testAutoRatio() {
         let autoRatio = BrickDimension.auto(estimate: BrickDimension.ratio(ratio: 0.5))
         XCTAssertEqual(autoRatio.value(for: 1000, startingAt: 0), 500)
-        XCTAssertEqual(autoRatio.dimension, autoRatio)
+        XCTAssertEqual(autoRatio.dimension(withValue: nil), autoRatio)
         XCTAssertTrue(autoRatio.isEstimate)
         XCTAssertEqual(autoRatio, BrickDimension.auto(estimate: BrickDimension.ratio(ratio: 0.5)))
     }
@@ -110,7 +110,7 @@ class BrickDimensionTests: XCTestCase {
         setupScreen(isPortrait: true, horizontalSizeClass: .compact, verticalSizeClass: .compact)
         let orientation = BrickDimension.orientation(landscape: BrickDimension.fixed(size: 100), portrait: BrickDimension.fixed(size: 50))
         XCTAssertEqual(orientation.value(for: 1000, startingAt: 0), 50)
-        XCTAssertEqual(orientation.dimension, BrickDimension.fixed(size: 50))
+        XCTAssertEqual(orientation.dimension(withValue: nil), BrickDimension.fixed(size: 50))
         XCTAssertEqual(orientation, BrickDimension.orientation(landscape: BrickDimension.fixed(size: 100), portrait: BrickDimension.fixed(size: 50)))
     }
 
@@ -118,7 +118,7 @@ class BrickDimensionTests: XCTestCase {
         setupScreen(isPortrait: false, horizontalSizeClass: .compact, verticalSizeClass: .compact)
         let orientation = BrickDimension.orientation(landscape: BrickDimension.fixed(size: 100), portrait: BrickDimension.fixed(size: 50))
         XCTAssertEqual(orientation.value(for: 1000, startingAt: 0), 100)
-        XCTAssertEqual(orientation.dimension, BrickDimension.fixed(size: 100))
+        XCTAssertEqual(orientation.dimension(withValue: nil), BrickDimension.fixed(size: 100))
         XCTAssertEqual(orientation, BrickDimension.orientation(landscape: BrickDimension.fixed(size: 100), portrait: BrickDimension.fixed(size: 50)))
     }
 
@@ -126,7 +126,7 @@ class BrickDimensionTests: XCTestCase {
         setupScreen(isPortrait: true, horizontalSizeClass: .compact, verticalSizeClass: .regular)
         let sizeClass = BrickDimension.horizontalSizeClass(regular: BrickDimension.fixed(size: 100), compact: BrickDimension.fixed(size: 50))
         XCTAssertEqual(sizeClass.value(for: 1000, startingAt: 0), 50)
-        XCTAssertEqual(sizeClass.dimension, BrickDimension.fixed(size: 50))
+        XCTAssertEqual(sizeClass.dimension(withValue: nil), BrickDimension.fixed(size: 50))
         XCTAssertEqual(sizeClass, BrickDimension.horizontalSizeClass(regular: BrickDimension.fixed(size: 100), compact: BrickDimension.fixed(size: 50)))
 
     }
@@ -135,7 +135,7 @@ class BrickDimensionTests: XCTestCase {
         setupScreen(isPortrait: true, horizontalSizeClass: .regular, verticalSizeClass: .compact)
         let sizeClass = BrickDimension.horizontalSizeClass(regular: BrickDimension.fixed(size: 100), compact: BrickDimension.fixed(size: 50))
         XCTAssertEqual(sizeClass.value(for: 1000, startingAt: 0), 100)
-        XCTAssertEqual(sizeClass.dimension, BrickDimension.fixed(size: 100))
+        XCTAssertEqual(sizeClass.dimension(withValue: nil), BrickDimension.fixed(size: 100))
         XCTAssertEqual(sizeClass, BrickDimension.horizontalSizeClass(regular: BrickDimension.fixed(size: 100), compact: BrickDimension.fixed(size: 50)))
     }
 
@@ -143,7 +143,7 @@ class BrickDimensionTests: XCTestCase {
         setupScreen(isPortrait: true, horizontalSizeClass: .regular, verticalSizeClass: .compact)
         let sizeClass = BrickDimension.verticalSizeClass(regular: BrickDimension.fixed(size: 100), compact: BrickDimension.fixed(size: 50))
         XCTAssertEqual(sizeClass.value(for: 1000, startingAt: 0), 50)
-        XCTAssertEqual(sizeClass.dimension, BrickDimension.fixed(size: 50))
+        XCTAssertEqual(sizeClass.dimension(withValue: nil), BrickDimension.fixed(size: 50))
         XCTAssertEqual(sizeClass, BrickDimension.verticalSizeClass(regular: BrickDimension.fixed(size: 100), compact: BrickDimension.fixed(size: 50)))
     }
 
@@ -151,7 +151,7 @@ class BrickDimensionTests: XCTestCase {
         setupScreen(isPortrait: true, horizontalSizeClass: .compact, verticalSizeClass: .regular)
         let sizeClass = BrickDimension.verticalSizeClass(regular: BrickDimension.fixed(size: 100), compact: BrickDimension.fixed(size: 50))
         XCTAssertEqual(sizeClass.value(for: 1000, startingAt: 0), 100)
-        XCTAssertEqual(sizeClass.dimension, BrickDimension.fixed(size: 100))
+        XCTAssertEqual(sizeClass.dimension(withValue: nil), BrickDimension.fixed(size: 100))
         XCTAssertEqual(sizeClass, BrickDimension.verticalSizeClass(regular: BrickDimension.fixed(size: 100), compact: BrickDimension.fixed(size: 50)))
     }
 
@@ -165,7 +165,7 @@ class BrickDimensionTests: XCTestCase {
                 compact: .auto(estimate: .fixed(size: 50))
             ))
         XCTAssertEqual(nested.value(for: 1000, startingAt: 0), 50)
-        XCTAssertEqual(nested.dimension, BrickDimension.auto(estimate: BrickDimension.fixed(size: 50)))
+        XCTAssertEqual(nested.dimension(withValue: nil), BrickDimension.auto(estimate: BrickDimension.fixed(size: 50)))
         XCTAssertTrue(nested.isEstimate)
         XCTAssertEqual(nested, BrickDimension.orientation(
             landscape: .fixed(size: 50),
@@ -173,6 +173,56 @@ class BrickDimensionTests: XCTestCase {
                 regular: .auto(estimate: .fixed(size: 100)),
                 compact: .auto(estimate: .fixed(size: 50))
             )))
+    }
+    
+    func testBrickRangeDimention() {
+        setupScreen(isPortrait: true, horizontalSizeClass: .compact, verticalSizeClass: .regular)
+        
+        let additionalRangePairs: [RangeDimensionPair] = [(dimension: .ratio(ratio: 0.5), minimumLength: CGFloat(350)),
+                                                     (dimension: .ratio(ratio: 0.25), minimumLength: CGFloat(700))]
+        let regularDimensionRange : BrickDimension = .dimensionRange(range: BrickRangeDimention(minimum: .ratio(ratio: 1.0), additionalRangePairs: additionalRangePairs))
+        XCTAssertEqual(regularDimensionRange.value(for: 320, startingAt: 0), 320)
+        setupScreen(isPortrait: true, horizontalSizeClass: .regular, verticalSizeClass: .regular)
+        XCTAssertEqual(regularDimensionRange.value(for: 350, startingAt: 0), 175)
+        XCTAssertEqual(regularDimensionRange.value(for: 768, startingAt: 0), 192)
+        XCTAssertEqual(regularDimensionRange.dimension(withValue: nil).value(for: 400, startingAt: 0), 400)
+    }
+    
+    func testVariableDimensionEquality() {
+        let additionalRangePairs1: [RangeDimensionPair] = [(dimension: .ratio(ratio: 1/2), minimumLength: CGFloat(350))]
+        let dimensionRange1: BrickDimension = .dimensionRange(range: BrickRangeDimention(minimum: .ratio(ratio: 1.0), additionalRangePairs: additionalRangePairs1))
+        let additionalRangePairs2: [RangeDimensionPair] = [(dimension: .ratio(ratio: 0.5), minimumLength: CGFloat(350))]
+        let dimensionRange2: BrickDimension = .dimensionRange(range: BrickRangeDimention(minimum: .ratio(ratio: 0.5 + 0.5), additionalRangePairs: additionalRangePairs2))
+        let additionalRangePairs3: [RangeDimensionPair] = [(dimension: .ratio(ratio: 1/3), minimumLength: CGFloat(350))]
+        let dimensionRange3: BrickDimension = .dimensionRange(range: BrickRangeDimention(minimum: .ratio(ratio: 1.0), additionalRangePairs: additionalRangePairs3))
+        let additionalRangePairs4: [RangeDimensionPair] = [(dimension: .ratio(ratio: 1/2), minimumLength: CGFloat(350))]
+        let dimensionRange4: BrickDimension = .dimensionRange(range: BrickRangeDimention(minimum: .ratio(ratio: 1.5), additionalRangePairs: additionalRangePairs4))
+        let additionalRangePairs5: [RangeDimensionPair] = [(dimension: .ratio(ratio: 1/2), minimumLength: CGFloat(350)), (dimension: .ratio(ratio: 1/3), minimumLength: CGFloat(500))]
+        let dimensionRange5: BrickDimension = .dimensionRange(range: BrickRangeDimention(minimum: .ratio(ratio: 1.5), additionalRangePairs: additionalRangePairs5))
+        XCTAssertEqual(dimensionRange1, dimensionRange2)
+        XCTAssertNotEqual(dimensionRange1, dimensionRange3)
+        XCTAssertNotEqual(dimensionRange1, dimensionRange4)
+        XCTAssertNotEqual(dimensionRange1, dimensionRange5)
+        
+        let dimensionPair1: RangeDimensionPair = (dimension: .ratio(ratio: 1/2), minimumLength: CGFloat(350))
+        let dimensionPair2: RangeDimensionPair = (dimension: .ratio(ratio: 0.25 * 2), minimumLength: (300.01 + 49.99))
+        let dimensionPair3: RangeDimensionPair = (dimension: .ratio(ratio: 0.25 * 2), minimumLength: (300.01 + 49.98))
+        let dimensionPair4: RangeDimensionPair = (dimension: .ratio(ratio: 1.5), minimumLength: CGFloat(350))
+        XCTAssertTrue(dimensionPair1 == dimensionPair2)
+        XCTAssertTrue(dimensionPair2 == dimensionPair1)
+        XCTAssertFalse(dimensionPair1 == dimensionPair3)
+        XCTAssertFalse(dimensionPair1 == dimensionPair4)
+        XCTAssertFalse(almostEqualRelative(A: 350, B: 350.001)) // Needed for code coverage completeness.
+    }
+    
+    func testNestedBrickRangeDimention() {
+        let additionalRangePairs: [RangeDimensionPair] = [(dimension: .ratio(ratio: 1/2), minimumLength: CGFloat(350)),
+                                                     (dimension: .ratio(ratio: 0.25), minimumLength: CGFloat(700))]
+        let nestedDimensionRange : BrickDimension = .dimensionRange(range: BrickRangeDimention(minimum: .ratio(ratio: 0.5), additionalRangePairs: additionalRangePairs))
+        let regularDimensionRange : BrickDimension = .dimensionRange(range: BrickRangeDimention(minimum: nestedDimensionRange, additionalRangePairs: nil))
+        XCTAssertEqual(regularDimensionRange.dimension(withValue: 200).value(for: 200, startingAt: 0), 100);
+        XCTAssertEqual(regularDimensionRange.dimension(withValue: 400).value(for: 400, startingAt: 0), 200);
+        XCTAssertEqual(regularDimensionRange.dimension(withValue: 800).value(for: 800, startingAt: 0), 200);
     }
 
     func testRawValue() {

--- a/Tests/Models/BrickDimensionTests.swift
+++ b/Tests/Models/BrickDimensionTests.swift
@@ -178,8 +178,8 @@ class BrickDimensionTests: XCTestCase {
     func testBrickRangeDimention() {
         setupScreen(isPortrait: true, horizontalSizeClass: .compact, verticalSizeClass: .regular)
         
-        let additionalRangePairs: [RangeDimensionPair] = [(dimension: .ratio(ratio: 0.5), minimumLength: CGFloat(350)),
-                                                     (dimension: .ratio(ratio: 0.25), minimumLength: CGFloat(700))]
+        let additionalRangePairs: [RangeDimensionPair] = [(dimension: .ratio(ratio: 0.25), minimumLength: CGFloat(700)),
+                                                          (dimension: .ratio(ratio: 0.5), minimumLength: CGFloat(350))] // Intentionally out of order
         let regularDimensionRange : BrickDimension = .dimensionRange(range: BrickRangeDimention(minimum: .ratio(ratio: 1.0), additionalRangePairs: additionalRangePairs))
         XCTAssertEqual(regularDimensionRange.value(for: 320, startingAt: 0), 320)
         setupScreen(isPortrait: true, horizontalSizeClass: .regular, verticalSizeClass: .regular)


### PR DESCRIPTION
Allows the BrickKit collection view controller to apply different dimensions based upon how wide the brick is. Starting with a minimum dimension that would be applicable to all widths, the app can the specify different dimensions for any additional widths.

100% code coverage for all additional code.
Added code to sample app to demonstrate support for it.
