### PR TITLE
Cleanup Sample App + Fixed “disapearing bricks”

### DIFF
--- a/Example/BrickKit-Example.xcodeproj/project.pbxproj
+++ b/Example/BrickKit-Example.xcodeproj/project.pbxproj
@@ -168,8 +168,10 @@
 		935D48911DB7CCC70091AA39 /* ImagesInCollectionBrickViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 935D488F1DB7CCC70091AA39 /* ImagesInCollectionBrickViewController.swift */; };
 		935D489B1DB7D1B10091AA39 /* ImagesInCollectionBrickHorizontalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 935D489A1DB7D1B10091AA39 /* ImagesInCollectionBrickHorizontalViewController.swift */; };
 		935D489C1DB7D1B10091AA39 /* ImagesInCollectionBrickHorizontalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 935D489A1DB7D1B10091AA39 /* ImagesInCollectionBrickHorizontalViewController.swift */; };
+		937C9C281F0F2F66008F47CD /* ReverseBrickViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 937C9C271F0F2F66008F47CD /* ReverseBrickViewController.swift */; };
 		938996A51DF77A3200E0F4F1 /* AlignmentBrickViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 938996A41DF77A3200E0F4F1 /* AlignmentBrickViewController.swift */; };
 		938996A61DF77A3200E0F4F1 /* AlignmentBrickViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 938996A41DF77A3200E0F4F1 /* AlignmentBrickViewController.swift */; };
+		93A0A1A51F0F36E5000ED3D4 /* ReverseBrickViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 937C9C271F0F2F66008F47CD /* ReverseBrickViewController.swift */; };
 		93AB641D1E67AA4800395CAA /* IsHiddenBrickViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93AB641C1E67AA4800395CAA /* IsHiddenBrickViewController.swift */; };
 		93AB641E1E67AA4800395CAA /* IsHiddenBrickViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93AB641C1E67AA4800395CAA /* IsHiddenBrickViewController.swift */; };
 		93D7E8691DFB52830031A6C2 /* InteractiveAlignViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93D7E8681DFB52830031A6C2 /* InteractiveAlignViewController.swift */; };
@@ -355,6 +357,7 @@
 		9357E7F51EDB4CAB0085AFFA /* TwoLabelView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TwoLabelView.swift; sourceTree = "<group>"; };
 		935D488F1DB7CCC70091AA39 /* ImagesInCollectionBrickViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImagesInCollectionBrickViewController.swift; sourceTree = "<group>"; };
 		935D489A1DB7D1B10091AA39 /* ImagesInCollectionBrickHorizontalViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImagesInCollectionBrickHorizontalViewController.swift; sourceTree = "<group>"; };
+		937C9C271F0F2F66008F47CD /* ReverseBrickViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReverseBrickViewController.swift; sourceTree = "<group>"; };
 		938996A41DF77A3200E0F4F1 /* AlignmentBrickViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlignmentBrickViewController.swift; sourceTree = "<group>"; };
 		93AB641C1E67AA4800395CAA /* IsHiddenBrickViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IsHiddenBrickViewController.swift; sourceTree = "<group>"; };
 		93D7E8681DFB52830031A6C2 /* InteractiveAlignViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InteractiveAlignViewController.swift; sourceTree = "<group>"; };
@@ -604,6 +607,7 @@
 		4E3BD7A31DB1316400541900 /* Simple */ = {
 			isa = PBXGroup;
 			children = (
+				937C9C271F0F2F66008F47CD /* ReverseBrickViewController.swift */,
 				4E3BD7A41DB1316400541900 /* MultiDimensionBrickViewController.swift */,
 				4E3BD7A51DB1316400541900 /* MultiSectionBrickViewController.swift */,
 				4E3BD7A61DB1316400541900 /* SimpleBrickViewController.swift */,
@@ -993,6 +997,7 @@
 				4E15F92C1DBA570600BBD363 /* MockTwitterViewController.swift in Sources */,
 				4E3BD7DE1DB1316400541900 /* SegmentHeaderBrick.swift in Sources */,
 				4E3BD8261DB1316400541900 /* HideSectionsViewController.swift in Sources */,
+				937C9C281F0F2F66008F47CD /* ReverseBrickViewController.swift in Sources */,
 				932365671DF449A500BE5183 /* FillBrickViewController.swift in Sources */,
 				4E3BD8241DB1316400541900 /* HideBrickViewController.swift in Sources */,
 				93EAFE2F1DB57D680036331C /* NavigationTransition.swift in Sources */,
@@ -1057,6 +1062,7 @@
 				4E3BD8551DB1316400541900 /* OnScrollDownStickingViewController.swift in Sources */,
 				4E3BD8E81DB51E1200541900 /* BrickIdentifiers.swift in Sources */,
 				4E3BD81F1DB1316400541900 /* BrickCollectionInteractiveViewController.swift in Sources */,
+				93A0A1A51F0F36E5000ED3D4 /* ReverseBrickViewController.swift in Sources */,
 				4E3BD7C91DB1316400541900 /* HeaderAndFooterBrick.swift in Sources */,
 				4E3BD84B1DB1316400541900 /* SimpleRepeatBrickViewController.swift in Sources */,
 				4E3BD82B1DB1316400541900 /* InvalidateHeightViewController.swift in Sources */,

--- a/Example/Source/Examples/BaseBrickController.swift
+++ b/Example/Source/Examples/BaseBrickController.swift
@@ -53,6 +53,16 @@ class BaseBrickController: BrickViewController {
     }
 }
 
+extension UILabel {
+
+    func configure(textColor: UIColor?) {
+        self.textAlignment = .center
+        self.textColor = textColor
+        self.numberOfLines = 0
+    }
+
+}
+
 extension LabelBrickCell {
 
     static func configure(cell: LabelBrickCell) {
@@ -60,8 +70,7 @@ extension LabelBrickCell {
     }
 
     func configure() {
-        label.textAlignment = .center
-        label.textColor = brick.backgroundColor.complemetaryColor
+        label.configure(textColor: brick.backgroundColor.complemetaryColor)
     }
 }
 

--- a/Example/Source/Examples/Collections/HorizontalScrollSectionBrickViewController.swift
+++ b/Example/Source/Examples/Collections/HorizontalScrollSectionBrickViewController.swift
@@ -68,11 +68,11 @@ class HorizontalScrollSectionBrickViewController: BrickApp.BaseBrickController, 
 }
 
 extension HorizontalScrollSectionBrickViewController: ImageBrickDataSource {
-    func imageForImageBrickCell(cell: ImageBrickCell) -> UIImage? {
+    func imageForImageBrickCell(_ cell: ImageBrickCell) -> UIImage? {
         return UIImage(named: "image\(cell.index)")
     }
 
-    func contentModeForImageBrickCell(imageBrickCell: ImageBrickCell) -> UIViewContentMode {
+    func contentModeForImageBrickCell(_ imageBrickCell: ImageBrickCell) -> UIViewContentMode {
         return .scaleAspectFill
     }
 }

--- a/Example/Source/Examples/Collections/RepeatCollectionBrickViewController.swift
+++ b/Example/Source/Examples/Collections/RepeatCollectionBrickViewController.swift
@@ -43,7 +43,6 @@ class RepeatCollectionBrickViewController: BrickApp.BaseBrickController, BrickRe
                 ])
             ], inset: 10, edgeInsets: UIEdgeInsets(top: 5, left: 5, bottom: 5, right: 5))
 
-        self.registerBrickClass(CollectionBrick.self)
 
         let section = BrickSection(bricks: [
             CollectionBrick(RepeatCollectionBrickViewController.Identifiers.collectionBrick, dataSource: self, brickTypes: [LabelBrick.self, ImageBrick.self])
@@ -67,7 +66,7 @@ class RepeatCollectionBrickViewController: BrickApp.BaseBrickController, BrickRe
 
 extension RepeatCollectionBrickViewController: CollectionBrickCellDataSource {
 
-    func sectionForCollectionBrickCell(cell: CollectionBrickCell) -> BrickSection {
+    func sectionForCollectionBrickCell(_ cell: CollectionBrickCell) -> BrickSection {
         return collectionSection
     }
     
@@ -78,7 +77,7 @@ extension RepeatCollectionBrickViewController: CollectionBrickCellDataSource {
 }
 
 extension RepeatCollectionBrickViewController: ImageBrickDataSource {
-    func imageForImageBrickCell(imageBrickCell: ImageBrickCell) -> UIImage? {
+    func imageForImageBrickCell(_ imageBrickCell: ImageBrickCell) -> UIImage? {
         return UIImage(named: "image\(imageBrickCell.collectionIndex)")
     }
 

--- a/Example/Source/Examples/HorizontalScroll/BlockHorizontalViewController.swift
+++ b/Example/Source/Examples/HorizontalScroll/BlockHorizontalViewController.swift
@@ -49,11 +49,11 @@ extension BlockHorizontalViewController: BrickRepeatCountDataSource {
 }
 
 extension BlockHorizontalViewController: ImageBrickDataSource {
-    func imageForImageBrickCell(cell: ImageBrickCell) -> UIImage? {
+    func imageForImageBrickCell(_ cell: ImageBrickCell) -> UIImage? {
         return UIImage(named: "image\(cell.index)")
     }
 
-    func contentModeForImageBrickCell(imageBrickCell: ImageBrickCell) -> UIViewContentMode {
+    func contentModeForImageBrickCell(_ imageBrickCell: ImageBrickCell) -> UIViewContentMode {
         return .scaleAspectFill
     }
 }

--- a/Example/Source/Examples/HorizontalScroll/HorizontalCollectionViewController.swift
+++ b/Example/Source/Examples/HorizontalScroll/HorizontalCollectionViewController.swift
@@ -70,18 +70,18 @@ extension HorizontalCollectionViewController: BrickRepeatCountDataSource {
 
 extension HorizontalCollectionViewController: CollectionBrickCellDataSource {
 
-    func sectionForCollectionBrickCell(cell: CollectionBrickCell) -> BrickSection {
+    func sectionForCollectionBrickCell(_ cell: CollectionBrickCell) -> BrickSection {
         return collectionSection
     }
 
 }
 
 extension HorizontalCollectionViewController: ImageBrickDataSource {
-    func imageForImageBrickCell(imageBrickCell: ImageBrickCell) -> UIImage? {
+    func imageForImageBrickCell(_ imageBrickCell: ImageBrickCell) -> UIImage? {
         return UIImage(named: "image\(imageBrickCell.collectionIndex)")
     }
 
-    func contentModeForImageBrickCell(imageBrickCell: ImageBrickCell) -> UIViewContentMode {
+    func contentModeForImageBrickCell(_ imageBrickCell: ImageBrickCell) -> UIViewContentMode {
         return .scaleAspectFill
     }
 }

--- a/Example/Source/Examples/Images/ImagesInCollectionBrickHorizontalViewController.swift
+++ b/Example/Source/Examples/Images/ImagesInCollectionBrickHorizontalViewController.swift
@@ -54,11 +54,11 @@ extension ImagesInCollectionBrickHorizontalViewController: BrickRepeatCountDataS
 }
 
 extension ImagesInCollectionBrickHorizontalViewController: ImageBrickDataSource {
-    func imageForImageBrickCell(cell: ImageBrickCell) -> UIImage? {
+    func imageForImageBrickCell(_ cell: ImageBrickCell) -> UIImage? {
         return UIImage(named: "image\(cell.index)")
     }
 
-    func contentModeForImageBrickCell(imageBrickCell: ImageBrickCell) -> UIViewContentMode {
+    func contentModeForImageBrickCell(_ imageBrickCell: ImageBrickCell) -> UIViewContentMode {
         return .scaleAspectFill
     }
 }

--- a/Example/Source/Examples/Images/ImagesInCollectionBrickViewController.swift
+++ b/Example/Source/Examples/Images/ImagesInCollectionBrickViewController.swift
@@ -54,11 +54,11 @@ extension ImagesInCollectionBrickViewController: BrickRepeatCountDataSource {
 }
 
 extension ImagesInCollectionBrickViewController: ImageBrickDataSource {
-    func imageForImageBrickCell(cell: ImageBrickCell) -> UIImage? {
+    func imageForImageBrickCell(_ cell: ImageBrickCell) -> UIImage? {
         return UIImage(named: "image\(cell.index)")
     }
 
-    func contentModeForImageBrickCell(imageBrickCell: ImageBrickCell) -> UIViewContentMode {
+    func contentModeForImageBrickCell(_ imageBrickCell: ImageBrickCell) -> UIViewContentMode {
         return .scaleAspectFill
     }
 }

--- a/Example/Source/Examples/Simple/ReverseBrickViewController.swift
+++ b/Example/Source/Examples/Simple/ReverseBrickViewController.swift
@@ -1,0 +1,64 @@
+//
+//  ReverseBrickViewController.swift
+//  BrickKit-Example
+//
+//  Created by Ruben Cagnie on 7/6/17.
+//  Copyright © 2017 Wayfair LLC. All rights reserved.
+//
+
+import Foundation
+import BrickKit
+
+class ReverseBrickViewController: BrickViewController, HasTitle {
+    class var brickTitle: String {
+        return "Reverse Bricks"
+    }
+
+    class var subTitle: String {
+        return "Bricks going from bottom to top"
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        self.view.backgroundColor = .brickBackground
+
+        let label = GenericBrick<UILabel>("Label1", height: .auto(estimate: .fixed(size: 50)), backgroundColor: .brickGray1) { label, cell in
+            cell.edgeInsets = UIEdgeInsets(top: 5, left: 5, bottom: 5, right: 5)
+
+            var text = "Label \(cell.index)"
+            for _ in 0..<(cell.index % 10) {
+                text += "\nrepeat"
+            }
+            label.text = text
+            label.configure(textColor: UIColor.brickGray1.complemetaryColor)
+        }
+        label.repeatCount = 5000
+
+        let section = BrickSection(bricks: [
+            label
+            ], inset: 20, edgeInsets: UIEdgeInsets(top: 20, left: 10, bottom: 20, right: 10))
+
+        self.setSection(section)
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        scrollToBottom()
+    }
+
+    func scrollToBottom() {
+        brickCollectionView.layoutSubviews()
+
+        let contentHeight = self.brickCollectionView.contentSize.height
+        let bottomOffset = CGPoint(x: 0, y: contentHeight - brickCollectionView.frame.height)
+        brickCollectionView.setContentOffset(bottomOffset, animated: false)
+
+        brickCollectionView.layoutSubviews()
+
+        if self.brickCollectionView.contentSize.height != contentHeight {
+            scrollToBottom()
+        }
+    }
+
+}

--- a/Example/Source/Examples/Simple/SimpleBrickViewController.swift
+++ b/Example/Source/Examples/Simple/SimpleBrickViewController.swift
@@ -22,8 +22,6 @@ class SimpleBrickViewController: BrickApp.BaseBrickController, HasTitle {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        self.registerBrickClass(LabelBrick.self)
-
         self.view.backgroundColor = .brickBackground
 
         let section = BrickSection(bricks: [

--- a/Example/Source/Navigation/NavigationDataSource.swift
+++ b/Example/Source/Navigation/NavigationDataSource.swift
@@ -45,6 +45,7 @@ class NavigationDataSource {
         NavigationItem(title: "Simple", subTitle: "Simple Examples", viewControllers: [
             SimpleBrickViewController.self,
             SimpleRepeatBrickViewController.self,
+            ReverseBrickViewController.self,
             HugeRepeatBrickViewController.self,
             HugeRepeatCollectionViewController.self,
             NibLessViewController.self,

--- a/Source/Bricks/Collection/CollectionBrick.swift
+++ b/Source/Bricks/Collection/CollectionBrick.swift
@@ -177,7 +177,7 @@ open class CollectionBrickCell: BrickCell, Bricklike, AsynchronousResizableCell 
     }
 
     open override func heightForBrickView(withWidth width: CGFloat) -> CGFloat {
-        return brickCollectionView.collectionViewLayout.collectionViewContentSize.height
+        return brickCollectionView.layout.collectionViewContentSize.height
     }
 
     open override func updateContent() {

--- a/Source/Layout/BrickLayoutInvalidationContext.swift
+++ b/Source/Layout/BrickLayoutInvalidationContext.swift
@@ -26,7 +26,7 @@ enum BrickLayoutInvalidationContextType {
      */
     var shouldInvalidateAllAttributes: Bool {
         switch self {
-        case .rotation, .invalidate, .creation, .updateVisibility, .invalidateDataSourceCounts(_)/*, .UpdateHeight(_)*/: return true
+        case .rotation, .invalidate, .creation, .updateVisibility, .invalidateDataSourceCounts(_), .updateHeight(_): return true
         default: return false
         }
     }

--- a/Tests/Bricks/CollectionBrickTests.swift
+++ b/Tests/Bricks/CollectionBrickTests.swift
@@ -58,8 +58,6 @@ class CollectionBrickTests: XCTestCase {
     }
 
     func testCollectionViewFrame() {
-        brickView.registerBrickClass(CollectionBrick.self)
-
         let collectionSection = BrickSection(bricks: [
             DummyBrick(height: .fixed(size: 200))
             ])
@@ -72,6 +70,8 @@ class CollectionBrickTests: XCTestCase {
         brickView.layoutSubviews()
 
         let cell1 = brickView.cellForItem(at: IndexPath(item: 0, section: 1)) as? CollectionBrickCell
+        XCTAssertEqual(cell1?.frame, CGRect(x: 0, y: 300, width: 320, height: 200))
+        cell1?.layoutIfNeeded()
         XCTAssertEqual(cell1?.brickCollectionView.frame, CGRect(x: 0, y: 0, width: 320, height: 200))
 
         XCTAssertFalse(brickView.layout.isInCollectionBrick)

--- a/Tests/Layout/BrickInvalidationContextTests.swift
+++ b/Tests/Layout/BrickInvalidationContextTests.swift
@@ -41,10 +41,6 @@ class BrickInvalidationContextTests: XCTestCase {
         let context = BrickLayoutInvalidationContext(type: .updateHeight(indexPath: IndexPath(item: 0, section: 1), newHeight: 100))
         brickViewController.layout.invalidateLayout(with: context)
 
-        XCTAssertEqual(context.invalidatedItemIndexPaths?.count, 4)
-        XCTAssertEqual(context.contentSizeAdjustment, CGSize(width: 0, height: 50))
-        XCTAssertEqual(context.contentOffsetAdjustment, CGPoint(x: 0, y: 0))
-
         let expectedResult = [
             0 : [
                 CGRect(x: 0, y: 0, width: width, height: 200),
@@ -79,9 +75,6 @@ class BrickInvalidationContextTests: XCTestCase {
         let context = BrickLayoutInvalidationContext(type: .updateHeight(indexPath: IndexPath(item: 1, section: 1), newHeight: 100))
         brickViewController.layout.invalidateLayout(with: context)
 
-        XCTAssertEqual(context.invalidatedItemIndexPaths?.count, 3)
-        XCTAssertEqual(context.contentSizeAdjustment, CGSize(width: 0, height: 50))
-
         let expectedResult = [
             0 : [
                 CGRect(x: 0, y: 0, width: width, height: 200),
@@ -114,9 +107,6 @@ class BrickInvalidationContextTests: XCTestCase {
 
         let context = BrickLayoutInvalidationContext(type: .updateHeight(indexPath: IndexPath(item: 2, section: 1), newHeight: 100))
         brickViewController.layout.invalidateLayout(with: context)
-        XCTAssertEqual(context.contentSizeAdjustment, CGSize(width: 0, height: 50))
-
-        XCTAssertEqual(context.invalidatedItemIndexPaths?.count, 2)
 
         let expectedResult = [
             0 : [
@@ -155,9 +145,6 @@ class BrickInvalidationContextTests: XCTestCase {
 
         let context = BrickLayoutInvalidationContext(type: .updateHeight(indexPath: IndexPath(item: 0, section: 2), newHeight: 100))
         brickViewController.layout.invalidateLayout(with: context)
-
-        XCTAssertEqual(context.invalidatedItemIndexPaths?.count, 7)
-        XCTAssertEqual(context.contentSizeAdjustment, CGSize(width: 0, height: 50))
 
         let expectedResult = [
             0 : [
@@ -208,9 +195,6 @@ class BrickInvalidationContextTests: XCTestCase {
         let context = BrickLayoutInvalidationContext(type: .updateHeight(indexPath: IndexPath(item: 0, section: 3), newHeight: 100))
         brickViewController.layout.invalidateLayout(with: context)
 
-        XCTAssertEqual(context.invalidatedItemIndexPaths?.count, 5)
-        XCTAssertEqual(context.contentSizeAdjustment, CGSize(width: 0, height: 50))
-
         let expectedResult = [
             0 : [
                 CGRect(x: 0, y: 0, width: width, height: 200),
@@ -260,9 +244,6 @@ class BrickInvalidationContextTests: XCTestCase {
 
         let context = BrickLayoutInvalidationContext(type: .updateHeight(indexPath: IndexPath(item: 0, section: 4), newHeight: 100))
         brickViewController.layout.invalidateLayout(with: context)
-
-        XCTAssertEqual(context.invalidatedItemIndexPaths?.count, 4)
-        XCTAssertEqual(context.contentSizeAdjustment, CGSize(width: 0, height: 50))
 
         let expectedResult = [
             0 : [
@@ -315,9 +296,6 @@ class BrickInvalidationContextTests: XCTestCase {
 
         let context = BrickLayoutInvalidationContext(type: .updateHeight(indexPath: IndexPath(item: 0, section: 4), newHeight: 100))
         brickViewController.layout.invalidateLayout(with: context)
-
-        XCTAssertEqual(context.invalidatedItemIndexPaths?.count, 6)
-        XCTAssertEqual(context.contentSizeAdjustment, CGSize(width: 0, height: 50))
 
         let expectedResult = [
             0 : [
@@ -375,9 +353,6 @@ class BrickInvalidationContextTests: XCTestCase {
         let context = BrickLayoutInvalidationContext(type: .updateHeight(indexPath: IndexPath(item: 0, section: 2), newHeight: 100))
         brickViewController.layout.invalidateLayout(with: context)
 
-        XCTAssertEqual(context.invalidatedItemIndexPaths?.count, 9)
-        XCTAssertEqual(context.contentSizeAdjustment, CGSize(width: 0, height: 50))
-
         let expectedResult = [
             0 : [
                 CGRect(x: 0, y: 0, width: width, height: 250),
@@ -434,9 +409,6 @@ class BrickInvalidationContextTests: XCTestCase {
         let context = BrickLayoutInvalidationContext(type: .updateHeight(indexPath: IndexPath(item: 0, section: 2), newHeight: 0))
         brickViewController.layout.invalidateLayout(with: context)
 
-        XCTAssertEqual(context.invalidatedItemIndexPaths?.count, 8)
-        //            XCTAssertEqual(context.contentSizeAdjustment, CGSize(width: 0, height: 50))
-
         let expectedResult = [
             0 : [
                 CGRect(x: 0, y: 0, width: width, height: 100),
@@ -488,9 +460,6 @@ class BrickInvalidationContextTests: XCTestCase {
 
         let context = BrickLayoutInvalidationContext(type: .updateHeight(indexPath: IndexPath(item: 1, section: 2), newHeight: 50))
         brickViewController.layout.invalidateLayout(with: context)
-
-        XCTAssertEqual(context.invalidatedItemIndexPaths?.count, 1)
-        XCTAssertEqual(context.contentSizeAdjustment, CGSize(width: 0, height: 0))
 
         let expectedResult = [
             0 : [
@@ -961,9 +930,6 @@ class BrickInvalidationContextTests: XCTestCase {
         let cell = brickViewController.brickCollectionView.cellForItem(at: IndexPath(item: 0, section: 1))
 
         XCTAssertEqual(cell?.frame, CGRect(x: 0, y: 0, width: width/2, height: 100))
-        XCTAssertEqual(context.invalidatedItemIndexPaths?.count, 3)
-        XCTAssertTrue(context.invalidatedItemIndexPaths!.contains(IndexPath(item: 0, section: 1)))
-        XCTAssertEqual(context.contentSizeAdjustment, CGSize(width: 0, height: 50))
 
         let expectedResult = [
             0 : [


### PR DESCRIPTION
- Cleanup the sample app. Mainly update protocols that changed function signatures, but had a default implementation, so the compiler didn’t complain
- Fixed a weird behavior when bricks would disappear when the estimated height of a brick was much bigger than the actual brick. This is solved by setting the `invalidateItems` to nil, so the collectionView will fetch the layoutAttributes again

Fixes #142