### PR TITLE
GenericBrick background color won’t reset to clear

### DIFF
--- a/Source/Bricks/Generic/GenericBrick.swift
+++ b/Source/Bricks/Generic/GenericBrick.swift
@@ -71,9 +71,29 @@ open class GenericBrickCell: BrickCell {
 
     internal private(set) var fromNib: Bool = false
 
+    public override init(frame: CGRect) {
+        super.init(frame: frame)
+        clearBackgroundColors()
+    }
+
+    public required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        clearBackgroundColors()
+    }
+
+    open override func prepareForReuse() {
+        super.prepareForReuse()
+        clearBackgroundColors()
+    }
+
     open override func awakeFromNib() {
         super.awakeFromNib()
         fromNib = true
+    }
+
+    fileprivate func clearBackgroundColors() {
+        backgroundColor = UIColor.clear
+        contentView.backgroundColor = UIColor.clear
     }
 
     open override func updateContent() {
@@ -82,9 +102,6 @@ open class GenericBrickCell: BrickCell {
         guard !fromNib else {
             return
         }
-
-        backgroundColor = UIColor.clear
-        contentView.backgroundColor = UIColor.clear
 
         if let generic = self._brick as? ViewGenerator {
             if let genericContentView = self.genericContentView {

--- a/Tests/Bricks/GenericBrickTests.swift
+++ b/Tests/Bricks/GenericBrickTests.swift
@@ -215,6 +215,12 @@ class GenericBrickTestBackgroundColor: GenericBrickTests {
         XCTAssertEqual(cell.contentView.backgroundColor, UIColor.orange)
     }
 
+    func testThatWhenReloadingTheBackgroundColorIsStillOrange() {
+        brickCollectionView.reloadBricksWithIdentifiers([GenericLabelBrickIdentifier])
+        cell = firstCellForIdentifier(GenericLabelBrickIdentifier)
+        XCTAssertEqual(cell.contentView.backgroundColor, UIColor.orange)
+    }
+
 }
 
 /// Test to verify adding an `accessoryView`


### PR DESCRIPTION
GenericBrick’s updateContent would clear the background colors. This caused a problem when reloading a cell with the actual reload via UICollectionView

Fixes #154