### PR TITLE
Optimize indexPath search using visible cells

### DIFF
--- a/Source/Cells/BrickCell.swift
+++ b/Source/Cells/BrickCell.swift
@@ -45,6 +45,29 @@ extension Bricklike where Self : BrickCell {
 
 open class BaseBrickCell: UICollectionViewCell {
 
+    open fileprivate(set) var index: Int = 0
+    open fileprivate(set) var collectionIndex: Int = 0
+    open fileprivate(set) var collectionIdentifier: String?
+
+    internal fileprivate(set) var _brick: Brick! {
+        didSet {
+            self.accessibilityIdentifier = _brick.accessibilityIdentifier
+            self.accessibilityLabel = _brick.accessibilityLabel
+            self.accessibilityHint = _brick.accessibilityHint
+        }
+    }
+
+    open var identifier: String {
+        return _brick.identifier
+    }
+
+    open func setContent(_ brick: Brick, index: Int, collectionIndex: Int, collectionIdentifier: String?) {
+        self._brick = brick
+        self.index = index
+        self.collectionIndex = collectionIndex
+        self.collectionIdentifier = collectionIdentifier
+    }
+
     // Using the UICollectionViewCell.backgroundView is not really stable
     // Especially when reusing cells, the backgroundView might disappear and reappear when scrolling up or down
     // The suspicion is that the `removeFromSuperview()` is called, even if the view is no longer part of the cell
@@ -112,22 +135,7 @@ extension BaseBrickCell {
 
 open class BrickCell: BaseBrickCell {
 
-    internal var _brick: Brick! {
-        didSet {
-            self.accessibilityIdentifier = _brick.accessibilityIdentifier
-            self.accessibilityLabel = _brick.accessibilityLabel
-            self.accessibilityHint = _brick.accessibilityHint
-        }
-    }
     open var tapGesture: UITapGestureRecognizer?
-
-    open var identifier: String {
-        return _brick.identifier
-    }
-
-    open fileprivate(set) var index: Int = 0
-    open fileprivate(set) var collectionIndex: Int = 0
-    open fileprivate(set) var collectionIdentifier: String?
 
     #if os(tvOS)
     @objc public var allowsFocus: Bool = true
@@ -164,11 +172,8 @@ open class BrickCell: BaseBrickCell {
         }
     }
 
-    open func setContent(_ brick: Brick, index: Int, collectionIndex: Int, collectionIdentifier: String?) {
-        self._brick = brick
-        self.index = index
-        self.collectionIndex = collectionIndex
-        self.collectionIdentifier = collectionIdentifier
+    open override func setContent(_ brick: Brick, index: Int, collectionIndex: Int, collectionIdentifier: String?) {
+        super.setContent(brick, index: index, collectionIndex: collectionIndex, collectionIdentifier: collectionIdentifier)
 
         self.isUserInteractionEnabled = true
         if let gesture = self.tapGesture {

--- a/Source/ViewControllers/BrickCollectionView.swift
+++ b/Source/ViewControllers/BrickCollectionView.swift
@@ -115,8 +115,29 @@ open class BrickCollectionView: UICollectionView {
         return brick
     }
 
+    open func indexPathsForVisibleBricksWithIdentifier(_ identifier: String, index: Int? = nil) -> [IndexPath] {
+        let cells = self.visibleCells.filter { (cell) -> Bool in
+            let brickCell = cell as! BaseBrickCell // It's ok to force unwrap because BrickKit only uses BaseBrickCell
+            if brickCell._brick.identifier == identifier {
+                if let index = index {
+                    return brickCell.index == index
+                }
+                return true
+            } else {
+                return false
+            }
+        }
+        return cells.flatMap({ (cell) -> IndexPath? in
+            return self.indexPath(for: cell)
+        })
+    }
+
     open func indexPathsForBricksWithIdentifier(_ identifier: String, index: Int? = nil) -> [IndexPath] {
-        return self.section.indexPathsForBricksWithIdentifier(identifier, index: index, in: collectionInfo)
+        var attributes = indexPathsForVisibleBricksWithIdentifier(identifier, index: index)
+        if attributes.isEmpty {
+            attributes = self.section.indexPathsForBricksWithIdentifier(identifier, index: index, in: collectionInfo)
+        }
+        return attributes
     }
 
     /// Register a brick class.
@@ -589,10 +610,9 @@ extension BrickCollectionView: UICollectionViewDataSource {
             if var downloadable = brickCell as? ImageDownloaderCell {
                 downloadable.imageDownloader = BrickCollectionView.imageDownloader
             }
-
-            brickCell.setContent(brick, index: info.index, collectionIndex: info.collectionIndex, collectionIdentifier: info.collectionIdentifier)
         }
 
+        cell.setContent(brick, index: info.index, collectionIndex: info.collectionIndex, collectionIdentifier: info.collectionIdentifier)
         cell.contentView.backgroundColor = brick.backgroundColor
 
         //  http://stackoverflow.com/questions/23059811/is-uicollectionview-backgroundview-broken

--- a/Tests/Bricks/GenericBrickTests.swift
+++ b/Tests/Bricks/GenericBrickTests.swift
@@ -160,7 +160,7 @@ class GenericBrickTestRepeatCount: GenericBrickTests {
         section.repeatCountDataSource = repeatCount
         brickCollectionView.setupSectionAndLayout(section)
 
-        indexPaths = brickCollectionView.indexPathsForBricksWithIdentifier(GenericLabelBrickIdentifier)
+        indexPaths = brickCollectionView.indexPathsForBricksWithIdentifier(GenericLabelBrickIdentifier).sorted(by: { $0.0.section < $0.1.section || $0.0.item < $0.1.item})
     }
 
     func testThatTheIndexPathCountIsTheSameAsTheRepeatCount() {

--- a/Tests/ViewControllers/BrickCollectionViewTests.swift
+++ b/Tests/ViewControllers/BrickCollectionViewTests.swift
@@ -205,16 +205,16 @@ class BrickCollectionViewTests: XCTestCase {
 
     func testIndexPathsForBricksWithIdentifier() {
         let section = BrickSection("Section1", bricks: [
-            DummyBrick("Brick1"),
+            DummyBrick("Brick1", height: .fixed(size: 50)),
             BrickSection("Section2", bricks: [
-                DummyBrick("Brick1"),
-                DummyBrick("Brick2")
+                DummyBrick("Brick1", height: .fixed(size: 50)),
+                DummyBrick("Brick2", height: .fixed(size: 50))
                 ])
             ])
         brickView.setupSectionAndLayout(section)
         XCTAssertEqual(brickView.indexPathsForBricksWithIdentifier("Section1"), [IndexPath(item: 0, section: 0)])
         XCTAssertEqual(brickView.indexPathsForBricksWithIdentifier("Section2"), [IndexPath(item: 1, section: 1)])
-        XCTAssertEqual(brickView.indexPathsForBricksWithIdentifier("Brick1"), [IndexPath(item: 0, section: 1), IndexPath(item: 0, section: 2)])
+        XCTAssertEqual(brickView.indexPathsForBricksWithIdentifier("Brick1").sorted(by: { $0.0.section < $0.1.section || $0.0.item < $0.1.item}), [IndexPath(item: 0, section: 1), IndexPath(item: 0, section: 2)])
         XCTAssertEqual(brickView.indexPathsForBricksWithIdentifier("Brick2"), [IndexPath(item: 1, section: 2)])
         XCTAssertEqual(brickView.indexPathsForBricksWithIdentifier("Brick3"), [])
     }


### PR DESCRIPTION
Searching for indexPaths could cause a lot of calculations. To find indexPaths for a given index, BrickKit will now first check the visible cells. If it can’t find it, it will continue to use the old, slower way

Fixes #152