### PR TITLE
Use Identifiers to register bricks and be able to register cell classes

### DIFF
--- a/Source/Models/BrickSection.swift
+++ b/Source/Models/BrickSection.swift
@@ -29,6 +29,8 @@ open class BrickSection: Brick {
     /// These nibs will be registered, when setting this BrickSection on a BrickCollectionView
     open var nibIdentifiers: [String: UINib]?
 
+    open var classIdentifiers: [String: AnyClass]?
+
     open internal(set) weak var brickCollectionView: BrickCollectionView?
 
     open weak var orderDataSource: BrickSectionOrderDataSource?

--- a/Source/ViewControllers/BrickCollectionView.swift
+++ b/Source/ViewControllers/BrickCollectionView.swift
@@ -52,6 +52,7 @@ open class BrickCollectionView: UICollectionView {
     open fileprivate(set) var section: BrickSection = BrickSection(bricks: []) {
         didSet {
             self.registerBricks(for: section, nibIdentifiers: section.nibIdentifiers)
+            self.registerBricks(for: section, classIdentifiers: section.classIdentifiers)
             section.invalidateCounts(in: collectionInfo)
             self.reloadData()
         }
@@ -205,6 +206,11 @@ open class BrickCollectionView: UICollectionView {
 
     internal func identifier(for brick: Brick) -> String? {
         let identifier: String
+
+        if let brickIdentifier = registeredBricks[brick.identifier] {
+            return brickIdentifier
+        }
+
         if brick is BrickSection {
             //Safeguard to never load the wrong nib for a BrickSection,
             //eventhough the identifier is actually in the registeredNibs
@@ -546,6 +552,20 @@ open class BrickCollectionView: UICollectionView {
                     self.registerNib(nib, forBrickWithIdentifier: brick.identifier)
                 } else  {
                     self.registerBrickClass(type(of: brick))
+                }
+            }
+        }
+    }
+
+    private func registerBricks(for section: BrickSection, classIdentifiers: [String: AnyClass]?) {
+        section.brickCollectionView = self
+        for brick in section.bricks {
+            if let brickSection = brick as? BrickSection {
+                registerBricks(for: brickSection, classIdentifiers: brickSection.classIdentifiers ?? classIdentifiers)
+            } else {
+                if let cellClass = classIdentifiers?[brick.identifier] {
+                    self.register(cellClass, forCellWithReuseIdentifier: brick.identifier)
+                    registeredBricks[brick.identifier] = brick.identifier
                 }
             }
         }

--- a/Tests/ViewControllers/BrickViewControllerTests.swift
+++ b/Tests/ViewControllers/BrickViewControllerTests.swift
@@ -346,6 +346,53 @@ class BrickViewControllerTests: XCTestCase {
 
     }
 
+    func testClassIdentifiersOnMultipleLabelBricks() {
+        let height:CGFloat = brickViewController.brickCollectionView.frame.height
+        let section = BrickSection("Test", bricks: [
+            LabelBrick("Brick1", height: .fixed(size: height), dataSource: LabelBrickCellModel(text: "Brick 1")),
+            LabelBrick("Brick2", height: .fixed(size: height), dataSource: LabelBrickCellModel(text: "Brick 2")),
+            LabelBrick("Brick3", height: .fixed(size: height), dataSource: LabelBrickCellModel(text: "Brick 3")),
+            LabelBrick("Brick4", height: .fixed(size: height), dataSource: LabelBrickCellModel(text: "Brick 4")),
+            LabelBrick("Brick5", height: .fixed(size: height), dataSource: LabelBrickCellModel(text: "Brick 5")),
+            LabelBrick("Brick6", height: .fixed(size: height), dataSource: LabelBrickCellModel(text: "Brick 6", configureCellBlock: {
+                (cell: LabelBrickCell) -> Void in
+                cell.accessoryView = UIImageView(image: UIImage(named: "image0"))
+            })),
+            LabelBrick("Brick7", height: .fixed(size: height), dataSource: LabelBrickCellModel(text: "Brick 5")),
+            LabelBrick("Brick8", height: .fixed(size: height), dataSource: LabelBrickCellModel(text: "Brick 5")),
+            LabelBrick("Brick9", height: .fixed(size: height), dataSource: LabelBrickCellModel(text: "Brick 5")),
+            LabelBrick("Brick10", height: .fixed(size: height), dataSource: LabelBrickCellModel(text: "Brick 5")),
+            LabelBrick("Brick11", height: .fixed(size: height), dataSource: LabelBrickCellModel(text: "Brick 5"))
+        ])
+        section.classIdentifiers = ["Brick1" : LabelBrickCell.self, "Brick2" : LabelBrickCell.self , "Brick3" : LabelBrickCell.self, "Brick4" : LabelBrickCell.self, "Brick5" : LabelBrickCell.self, "Brick6" : LabelBrickCell.self, "Brick7" : LabelBrickCell.self, "Brick8" : LabelBrickCell.self, "Brick9" : LabelBrickCell.self, "Brick10" : LabelBrickCell.self, "Brick11" : LabelBrickCell.self]
+
+        brickViewController.brickCollectionView.setupSectionAndLayout(section)
+
+        if let indexPath6 = brickViewController.brickCollectionView.indexPathsForBricksWithIdentifier("Brick6").first {
+
+            brickViewController.brickCollectionView.contentOffset.y += height * 5
+            brickViewController.brickCollectionView.layoutSubviews()
+
+            guard let labelBrick6 = brickViewController.brickCollectionView.cellForItem(at: indexPath6) as? LabelBrickCell else {
+                XCTFail("LabelBrickCell should not be nil")
+                return
+            }
+
+            XCTAssertNotNil(labelBrick6.accessoryView)
+
+            brickViewController.brickCollectionView.contentOffset.y += height * 4
+            brickViewController.brickCollectionView.layoutSubviews()
+
+            brickViewController.brickCollectionView.contentOffset.y -= height * 9
+            brickViewController.brickCollectionView.layoutSubviews()
+
+            for cell in brickViewController.brickCollectionView.visibleCells where brickViewController.brickCollectionView.cellForItem(at: indexPath6) == nil {
+                if let cell = cell as? LabelBrickCell {
+                    XCTAssertNil(cell.accessoryView)
+                }
+            }
+        }
+    }
 
     func testInsets() {
         let size = CGSize(width: 100, height: 100)


### PR DESCRIPTION
Adds a dictionary field to brick section so that we are able to register a class for a given identifier if we do not a brick to be reused across the class. This is something that can be used when we use a lot of different label bricks.