### PR TITLE
Checks if _brick!=nil before calling framesDidLayout().

### DIFF
--- a/Source/Bricks/Image/ImageBrick.swift
+++ b/Source/Bricks/Image/ImageBrick.swift
@@ -184,7 +184,17 @@ open class ImageBrickCell: GenericBrickCell, Bricklike, AsynchronousResizableCel
             }
             
             imageLoaded = true
-        } else if let imageURL = dataSource.imageURLForImageBrickCell(self) {
+        }
+    }
+
+    override open func framesDidLayout() {
+        super.framesDidLayout()
+
+        guard let dataSource = brick.dataSource, !imageLoaded else {
+            return
+        }
+
+        if let imageURL = dataSource.imageURLForImageBrickCell(self) {
             guard currentImageURL != imageURL else {
                 if let image = self.imageView.image {
                     self.resize(image: image)

--- a/Source/Cells/BrickCell.swift
+++ b/Source/Cells/BrickCell.swift
@@ -19,7 +19,7 @@ public protocol AsynchronousResizableDelegate: class {
 }
 
 public protocol ImageDownloaderCell {
-    var imageDownloader: ImageDownloader? { get set }
+    weak var imageDownloader: ImageDownloader? { get set }
 }
 
 public protocol BrickCellTapDelegate: UIGestureRecognizerDelegate {
@@ -106,16 +106,19 @@ open class BaseBrickCell: UICollectionViewCell {
         // UICollectionView zIndex management 'fixes' the issue
         // http://stackoverflow.com/questions/12659301/uicollectionview-setlayoutanimated-not-preserving-zindex
         self.layer.zPosition = CGFloat(layoutAttributes.zIndex)
-        self.layoutIfNeeded()
+
+        if self is AsynchronousResizableCell {
+            self.layoutIfNeeded()
+        }
     }
 
     open override func layoutSubviews() {
         super.layoutSubviews()
         brickBackgroundView?.frame = self.bounds
 
-        if frame.width == requestedWidth {
+        if _brick != nil && frame.width == requestedWidth {
             self.layoutIfNeeded() // This layoutIfNeeded is added to make sure that the subviews are laid out correctly
-            framesDidLayout()
+            self.framesDidLayout()
         }
     }
 

--- a/Source/Cells/ImageDownloader.swift
+++ b/Source/Cells/ImageDownloader.swift
@@ -9,18 +9,17 @@
 import UIKit
 
 private func _downloadImageAndSet(_ imageDownloader: ImageDownloader, on imageView: UIImageView, with imageURL: URL, onCompletion completionHandler: @escaping ((_ image: UIImage, _ url: URL) -> Void)) {
-    
-    imageDownloader.downloadImage(with: imageURL) { (image, url) in
+
+    imageDownloader.downloadImage(with: imageURL) { (image: UIImage, url: URL) in
         guard imageURL == url else {
             return
         }
 
-        OperationQueue.main.addOperation {
+        DispatchQueue.main.async {
             imageView.image = image
             completionHandler(image, url)
         }
     }
-
 }
 
 // Mark: - Image Downloader

--- a/Tests/Cells/FrameInfoBrick.swift
+++ b/Tests/Cells/FrameInfoBrick.swift
@@ -20,6 +20,7 @@ class FrameInfoBrickCell: BrickCell, Bricklike {
     var firstReportedImageViewFrame: CGRect?
 
     override open func framesDidLayout() {
+        super.framesDidLayout()
         if firstReportedImageViewFrame == nil {
             firstReportedImageViewFrame = self.imageView.frame
         }


### PR DESCRIPTION
This fixes a run-time crash during dequeing a cell while brick hasn’t yet been set.  Checks if it’s an AsynchronouseResizableCell before calling layoutIfNeeded during the attribute pass.