### PR TITLE
Image view now shows the correct image when the cell is reused

### DIFF
--- a/Source/Bricks/Image/ImageBrick.swift
+++ b/Source/Bricks/Image/ImageBrick.swift
@@ -208,6 +208,13 @@ open class ImageBrickCell: GenericBrickCell, Bricklike, AsynchronousResizableCel
             imageView.image = nil
         }
     }
+    
+    override open func prepareForReuse() {
+        super.prepareForReuse()
+        imageView.image = nil
+        currentImageURL = nil
+        imageLoaded = false
+    }
 
 
     fileprivate func resize(image: UIImage) {

--- a/Tests/Bricks/ImageBrickTests.swift
+++ b/Tests/Bricks/ImageBrickTests.swift
@@ -202,11 +202,9 @@ class ImageBrickTests: XCTestCase {
     func testURLSetOnMainQueue() {
         var expectation: XCTestExpectation? = self.expectation(description: "testURLSetOnMainQueue - Wait for image to download")
         let fixedImageDownloader = FixedNSURLSessionImageDownloader { (success) in
-            XCTAssertEqual(OperationQueue.main.operationCount, 1)
-            DispatchQueue.main.async {
-                expectation?.fulfill()
-                expectation = nil
-            }
+            XCTAssertFalse(Thread.isMainThread)
+            expectation?.fulfill()
+            expectation = nil
         }
 
         BrickCollectionView.imageDownloader = fixedImageDownloader
@@ -287,6 +285,40 @@ class ImageBrickTests: XCTestCase {
         XCTAssertTrue(delegate.didUpdateCalled)
         XCTAssertEqualWithAccuracy(cell2!.frame.height, 320 * ratio, accuracy: 0.5)
         XCTAssertEqualWithAccuracy(cell2!.imageView.frame.height, 320 * ratio, accuracy: 0.5)
+    }
+    
+    func testImageResetsBeforeReusing() {
+        var expectation: XCTestExpectation? = self.expectation(description: "testImageResetsBeforeReusing - Wait for image to download")
+        
+        let fixedImageDownloader = FixedNSURLSessionImageDownloader { (success) in
+            DispatchQueue.main.async {
+                expectation?.fulfill()
+                expectation = nil
+            }
+        }
+        
+        BrickCollectionView.imageDownloader = fixedImageDownloader
+        
+        brickView.registerBrickClass(ImageBrick.self)
+        
+        let section = BrickSection(bricks: [
+            ImageBrick("imageBrick", dataSource: ImageURLBrickModel(url: imageURL, contentMode: .scaleAspectFill)),
+            ])
+        
+        brickView.setSection(section)
+        brickView.layoutSubviews()
+        
+        let cell1 = brickView.cellForItem(at: IndexPath(item: 0, section: 1)) as? ImageBrickCell
+        cell1?.imageView.image = self.image
+        cell1?.layoutIfNeeded()
+        
+        waitForExpectations(timeout: 10, handler: nil)
+
+        
+        XCTAssertFalse(cell1?.imageView.image == nil)
+        cell1?.prepareForReuse()
+        XCTAssertTrue(cell1?.imageView.image == nil)
+        
     }
 }
 


### PR DESCRIPTION
This fixes a bug that causes an image brick cell to not properly reset before reusing it. 