### PR TITLE
Performance Improvements

### DIFF
--- a/Source/Behaviors/BrickLayoutBehavior.swift
+++ b/Source/Behaviors/BrickLayoutBehavior.swift
@@ -25,6 +25,10 @@ open class BrickLayoutBehavior: NSObject {
     open func sectionAttributes(for indexPath: IndexPath, in layout: UICollectionViewLayout) -> BrickLayoutAttributes? {
         return brickFlowLayout?.layoutAttributesForSection(indexPath.section)
     }
+    
+    open func hasInvalidatableAttributes() -> Bool {
+        return true
+    }
 
     open func resetRegisteredAttributes(_ collectionViewLayout: UICollectionViewLayout) {
         //Optional

--- a/Source/Behaviors/CardLayoutBehavior.swift
+++ b/Source/Behaviors/CardLayoutBehavior.swift
@@ -28,7 +28,7 @@ open class CardLayoutBehavior: BrickLayoutBehavior {
     
     open override func hasInvalidatableAttributes() -> Bool {
         // Only return true if there is at least one attribute that's not hidden
-        return !scrollAttributes.filter({ !$0.isHidden }).isEmpty
+        return scrollAttributes.contains { !$0.isHidden }
     }
 
     open override func resetRegisteredAttributes(_ collectionViewLayout: UICollectionViewLayout) {

--- a/Source/Behaviors/CardLayoutBehavior.swift
+++ b/Source/Behaviors/CardLayoutBehavior.swift
@@ -25,6 +25,11 @@ open class CardLayoutBehavior: BrickLayoutBehavior {
     public init(dataSource: CardLayoutBehaviorDataSource) {
         self.dataSource = dataSource
     }
+    
+    open override func hasInvalidatableAttributes() -> Bool {
+        // Only return true if there is at least one attribute that's not hidden
+        return !scrollAttributes.filter({ !$0.isHidden }).isEmpty
+    }
 
     open override func resetRegisteredAttributes(_ collectionViewLayout: UICollectionViewLayout) {
         super.resetRegisteredAttributes(collectionViewLayout)

--- a/Source/Behaviors/OffsetLayoutBehavior.swift
+++ b/Source/Behaviors/OffsetLayoutBehavior.swift
@@ -28,7 +28,7 @@ open class OffsetLayoutBehavior: BrickLayoutBehavior {
     
     open override func hasInvalidatableAttributes() -> Bool {
         // Only return true if there is at least one attribute that's not hidden
-        return !offsetAttributes.filter({ !$0.isHidden }).isEmpty
+        return offsetAttributes.contains { !$0.isHidden }
     }
 
     open override func resetRegisteredAttributes(_ collectionViewLayout: UICollectionViewLayout) {

--- a/Source/Behaviors/OffsetLayoutBehavior.swift
+++ b/Source/Behaviors/OffsetLayoutBehavior.swift
@@ -25,6 +25,11 @@ open class OffsetLayoutBehavior: BrickLayoutBehavior {
     public init(dataSource: OffsetLayoutBehaviorDataSource) {
         self.dataSource = dataSource
     }
+    
+    open override func hasInvalidatableAttributes() -> Bool {
+        // Only return true if there is at least one attribute that's not hidden
+        return !offsetAttributes.filter({ !$0.isHidden }).isEmpty
+    }
 
     open override func resetRegisteredAttributes(_ collectionViewLayout: UICollectionViewLayout) {
         super.resetRegisteredAttributes(collectionViewLayout)

--- a/Source/Behaviors/SpotlightLayoutBehavior.swift
+++ b/Source/Behaviors/SpotlightLayoutBehavior.swift
@@ -31,7 +31,7 @@ open class SpotlightLayoutBehavior: BrickLayoutBehavior {
 
     open override func hasInvalidatableAttributes() -> Bool {
         // Only return true if there is at least one attribute that's not hidden
-        return !scrollAttributes.filter({ !$0.isHidden }).isEmpty
+        return scrollAttributes.contains { !$0.isHidden }
     }
     
     open override func resetRegisteredAttributes(_ collectionViewLayout: UICollectionViewLayout) {

--- a/Source/Behaviors/SpotlightLayoutBehavior.swift
+++ b/Source/Behaviors/SpotlightLayoutBehavior.swift
@@ -29,6 +29,11 @@ open class SpotlightLayoutBehavior: BrickLayoutBehavior {
         self.dataSource = dataSource
     }
 
+    open override func hasInvalidatableAttributes() -> Bool {
+        // Only return true if there is at least one attribute that's not hidden
+        return !scrollAttributes.filter({ !$0.isHidden }).isEmpty
+    }
+    
     open override func resetRegisteredAttributes(_ collectionViewLayout: UICollectionViewLayout) {
         scrollAttributes = []
     }

--- a/Source/Behaviors/StickyLayoutBehavior.swift
+++ b/Source/Behaviors/StickyLayoutBehavior.swift
@@ -34,6 +34,11 @@ open class StickyLayoutBehavior: BrickLayoutBehavior {
         self.delegate = delegate
         self.contentOffset = contentOffset
     }
+    
+    open override func hasInvalidatableAttributes() -> Bool {
+        // Only return true if there is at least one attribute that's not hidden
+        return !stickyAttributes.filter({ !$0.isHidden }).isEmpty
+    }
 
     open override func resetRegisteredAttributes(_ collectionViewLayout: UICollectionViewLayout) {
         super.resetRegisteredAttributes(collectionViewLayout)

--- a/Source/Behaviors/StickyLayoutBehavior.swift
+++ b/Source/Behaviors/StickyLayoutBehavior.swift
@@ -23,7 +23,7 @@ open class StickyLayoutBehavior: BrickLayoutBehavior {
     weak var dataSource: StickyLayoutBehaviorDataSource?
     weak var delegate: StickyLayoutBehaviorDelegate?
     open var contentOffset: CGFloat
-    var stickyAttributes: [BrickLayoutAttributes]!
+    var stickyAttributes: [BrickLayoutAttributes] = []
 
     fileprivate(set) var stickyZIndex = 1
 
@@ -37,7 +37,7 @@ open class StickyLayoutBehavior: BrickLayoutBehavior {
     
     open override func hasInvalidatableAttributes() -> Bool {
         // Only return true if there is at least one attribute that's not hidden
-        return !stickyAttributes.filter({ !$0.isHidden }).isEmpty
+        return stickyAttributes.contains { !$0.isHidden }
     }
 
     open override func resetRegisteredAttributes(_ collectionViewLayout: UICollectionViewLayout) {

--- a/Source/Bricks/Generic/GenericBrick.swift
+++ b/Source/Bricks/Generic/GenericBrick.swift
@@ -17,6 +17,10 @@ public protocol UpdateFramesListener {
     func didUpdateFrames()
 }
 
+public protocol CustomHeightProvider {
+    func customHeight(for view: UIView, constraintedTo width: CGFloat) -> CGFloat
+}
+
 open class GenericBrick<T: UIView>: Brick, ViewGenerator {
     public typealias ConfigureView = (_ view: T, _ cell: GenericBrickCell) -> Void
 
@@ -72,6 +76,8 @@ open class GenericBrickCell: BrickCell {
             }
         }
     }
+    
+    open var customHeightProvider: CustomHeightProvider?
 
     internal private(set) var fromNib: Bool = false
 
@@ -185,6 +191,15 @@ open class GenericBrickCell: BrickCell {
 
         if let genericContentView = genericContentView as? UpdateFramesListener {
             genericContentView.didUpdateFrames()
+        }
+    }
+    
+    open override func heightForBrickView(withWidth width: CGFloat) -> CGFloat {
+        if let heightProvider = customHeightProvider {
+            let height = heightProvider.customHeight(for: self.genericContentView!, constraintedTo: width)
+            return height
+        } else {
+            return super.heightForBrickView(withWidth: width)
         }
     }
 

--- a/Source/Layout/BrickFlowLayout.swift
+++ b/Source/Layout/BrickFlowLayout.swift
@@ -277,7 +277,7 @@ extension BrickFlowLayout {
             contentOffset = newBounds.origin
             // Don't want to return true if there are behaviors but no attributes assigned
             // to these behaviors, otherwise the collection view will invalidate every index path.
-            return !behaviors.filter({ $0.hasInvalidatableAttributes() }).isEmpty
+            return behaviors.contains { $0.hasInvalidatableAttributes() }
         }
 
         return false

--- a/Source/Layout/BrickFlowLayout.swift
+++ b/Source/Layout/BrickFlowLayout.swift
@@ -275,7 +275,9 @@ extension BrickFlowLayout {
             return true
         } else if contentOffset != newBounds.origin {
             contentOffset = newBounds.origin
-            return !behaviors.isEmpty
+            // Don't want to return true if there are behaviors but no attributes assigned
+            // to these behaviors, otherwise the collection view will invalidate every index path.
+            return !behaviors.filter({ $0.hasInvalidatableAttributes() }).isEmpty
         }
 
         return false

--- a/Source/Layout/BrickLayoutSection.swift
+++ b/Source/Layout/BrickLayoutSection.swift
@@ -661,7 +661,6 @@ internal class BrickLayoutSection {
         let oldOriginalFrame: CGRect?
 
         if existingAttribute {
-            brickAttributes = attributes[index]
             oldFrame = brickAttributes.frame
             oldOriginalFrame = brickAttributes.originalFrame
 

--- a/Source/Models/BrickDimension.swift
+++ b/Source/Models/BrickDimension.swift
@@ -27,21 +27,20 @@ public typealias RangeDimensionPair = (dimension: BrickDimension, minimumSize: C
 
 public struct BrickRangeDimension {
     
-    internal var dimensionPairs : [RangeDimensionPair]
+    internal var defaultPair : RangeDimensionPair
+    internal var additionalPairs : [RangeDimensionPair]
     
     public init(default dimension: BrickDimension, additionalRangePairs: [RangeDimensionPair] = []) {
-        dimensionPairs = [(dimension, 0)]
-        dimensionPairs.append(contentsOf: additionalRangePairs.sorted {
-            $0.minimumSize < $1.minimumSize
-        })
+        defaultPair = (dimension, 0)
+        additionalPairs = additionalRangePairs
     }
     
     public func dimension(forWidth width: CGFloat?) -> BrickDimension {
         guard let width = width  else {
-            return dimensionPairs.first!.dimension
+            return defaultPair.dimension
         }
-        var dimension = dimensionPairs.first?.dimension
-        for RangeDimensionPair in dimensionPairs {
+        var dimension = defaultPair.dimension
+        for RangeDimensionPair in additionalPairs {
             if RangeDimensionPair.minimumSize > width {
                 break
             }
@@ -49,7 +48,7 @@ public struct BrickRangeDimension {
                 dimension = RangeDimensionPair.dimension
             }
         }
-        return dimension!
+        return dimension
     }
 }
 
@@ -73,11 +72,14 @@ public func ==(lhs: RangeDimensionPair, rhs: RangeDimensionPair) -> Bool {
 }
 
 public func ==(lhs: BrickRangeDimension, rhs: BrickRangeDimension) -> Bool {
-    if lhs.dimensionPairs.count != rhs.dimensionPairs.count {
+    if lhs.additionalPairs.count != rhs.additionalPairs.count {
         return false
     }
-    for (index, value) in lhs.dimensionPairs.enumerated() {
-        if value != rhs.dimensionPairs[index] {
+    if lhs.defaultPair != rhs.defaultPair {
+        return false
+    }
+    for (index, value) in lhs.additionalPairs.enumerated() {
+        if value != rhs.additionalPairs[index] {
             return false
         }
     }

--- a/Tests/Behaviors/CardLayoutBehaviorTests.swift
+++ b/Tests/Behaviors/CardLayoutBehaviorTests.swift
@@ -43,6 +43,11 @@ class CardLayoutBehaviorTests: BrickFlowLayoutBaseTests {
 
         super.tearDown()
     }
+    
+    func testEmptyCardLayoutBehaviorDataSource() {
+        let emptyCardLayoutBehavior = CardLayoutBehavior(dataSource: FixedCardLayoutBehaviorDataSource(height: nil))
+        XCTAssertFalse(emptyCardLayoutBehavior.hasInvalidatableAttributes())
+    }
 
     func testCardScrollBehavior() {
 
@@ -61,6 +66,7 @@ class CardLayoutBehaviorTests: BrickFlowLayoutBaseTests {
         XCTAssertEqual(layout.collectionViewContentSize, CGSize(width: 320, height: 1200))
 
         layout.collectionView?.contentOffset.y = 100
+        XCTAssertTrue(behavior.hasInvalidatableAttributes())
         layout.invalidateLayout(with: BrickLayoutInvalidationContext(type: .scrolling))
 
         firstAttributes = layout.layoutAttributesForItem(at: IndexPath(item: 0, section: 0))

--- a/Tests/Behaviors/CoverFlowLayoutBehaviorTests.swift
+++ b/Tests/Behaviors/CoverFlowLayoutBehaviorTests.swift
@@ -56,6 +56,7 @@ class CoverFlowLayoutBehaviorTests: XCTestCase {
         XCTAssertEqualWithAccuracy(cell2!.transform.scaleY, 1, accuracy: 0.01)
         XCTAssertEqualWithAccuracy(cell3!.transform.scaleX, 2/3, accuracy: 0.01)
         XCTAssertEqualWithAccuracy(cell3!.transform.scaleY, 2/3, accuracy: 0.01)
+        XCTAssertTrue(coverFlowBehavior.hasInvalidatableAttributes())
     }
 
 

--- a/Tests/Behaviors/MaxZIndexBehaviorTests.swift
+++ b/Tests/Behaviors/MaxZIndexBehaviorTests.swift
@@ -28,6 +28,10 @@ class MaxZIndexBehaviorTests: BrickFlowLayoutBaseTests {
         let attributes2 = layout.layoutAttributesForItem(at: IndexPath(item: 1, section: 0))
         XCTAssertNotNil(attributes2)
         XCTAssertEqual(attributes2?.zIndex, 21)
+        
+        // Not ideal to always return true but no way to easily determine if there are no index paths given to the datasource
+        // that would satisfy the behavior for this to be false.
+        XCTAssertTrue(zIndexBehavior.hasInvalidatableAttributes())
     }
 
 }

--- a/Tests/Behaviors/MinimumStickyLayoutBehaviorTests.swift
+++ b/Tests/Behaviors/MinimumStickyLayoutBehaviorTests.swift
@@ -146,9 +146,19 @@ class MinimumStickyLayoutBehaviorTests: BrickFlowLayoutBaseTests {
 
         firstAttributes = layout.layoutAttributesForItem(at: IndexPath(item: 0, section: 0))
         XCTAssertEqual(firstAttributes?.frame, CGRect(x: 0, y: 500, width: 320, height: 100))
+        XCTAssertTrue(stickyBehavior.hasInvalidatableAttributes())
         
     }
     
-
+    func testNoInvalitableAttributes() {
+        let fixedStickyWithMinimumLayoutBehavior = FixedStickyLayoutBehaviorDataSource(indexPaths: [IndexPath(item: 20, section: 0)]) // IndexPath is just out of section count.
+        let stickyBehavior = MinimumStickyLayoutBehavior(dataSource: fixedStickyWithMinimumLayoutBehavior)
+        self.layout.behaviors.insert(stickyBehavior)
+        let sectionCount = 20
+        setDataSources(SectionsCollectionViewDataSource(sections: [sectionCount]), brickLayoutDataSource: FixedBrickLayoutDataSource(widthRatio: 1, height: 100))
+        layout.collectionView?.contentOffset.y = 25
+        layout.invalidateLayout(with: BrickLayoutInvalidationContext(type: .scrolling))
+        XCTAssertFalse(stickyBehavior.hasInvalidatableAttributes())
+    }
 
 }

--- a/Tests/Behaviors/OffsetLayoutBehaviorTests.swift
+++ b/Tests/Behaviors/OffsetLayoutBehaviorTests.swift
@@ -22,7 +22,7 @@ class OffsetLayoutBehaviorTests: BrickFlowLayoutBaseTests {
         behavior = OffsetLayoutBehavior(dataSource: FixedOffsetLayoutBehaviorDataSource(originOffset: CGSize(width: 20, height: -40), sizeOffset: nil))
         self.layout.behaviors.insert(behavior)
         setDataSources(SectionsCollectionViewDataSource(sections: []), brickLayoutDataSource: FixedBrickLayoutDataSource(widthRatio: 1, height: 300))
-
+        XCTAssertFalse(behavior.hasInvalidatableAttributes())
         let attributes = layout.layoutAttributesForItem(at: IndexPath(item: 0, section: 0))
         XCTAssertNil(attributes?.frame)
     }
@@ -68,6 +68,7 @@ class OffsetLayoutBehaviorTests: BrickFlowLayoutBaseTests {
         XCTAssertEqual(attributes?.frame, CGRect(x: 20, y: -40, width: 280, height: 320))
 
         layout.collectionView?.contentOffset.y = 60
+        XCTAssertTrue(behavior.hasInvalidatableAttributes())
         layout.invalidateLayout(with: BrickLayoutInvalidationContext(type: .scrolling))
         XCTAssertEqual(attributes?.frame, CGRect(x: 20, y: -40, width: 280, height: 320))
     }

--- a/Tests/Behaviors/SetZIndexBehaviorTests.swift
+++ b/Tests/Behaviors/SetZIndexBehaviorTests.swift
@@ -26,6 +26,10 @@ class SetZIndexBehaviorTests: BrickFlowLayoutBaseTests {
         let attributes2 = layout.layoutAttributesForItem(at: IndexPath(item: 1, section: 0))
         XCTAssertNotNil(attributes2)
         XCTAssertEqual(attributes2?.zIndex, 22)
+        
+        // Not ideal to always return true but no way to easily determine if there are no index paths given to the datasource 
+        // that would satisfy the behavior for this to be false.
+        XCTAssertTrue(zIndexBehavior.hasInvalidatableAttributes())
     }
 
 }

--- a/Tests/Behaviors/SpotlightLayoutBehaviorTests.swift
+++ b/Tests/Behaviors/SpotlightLayoutBehaviorTests.swift
@@ -46,6 +46,8 @@ class SpotlightLayoutBehaviorTests: BrickFlowLayoutBaseTests {
 
     func testSpotlightBehavior() {
         setupWithDataSources()
+        
+        XCTAssertTrue(behavior.hasInvalidatableAttributes())
 
         firstAttributes = layout.layoutAttributesForItem(at: IndexPath(item: 0, section: 0))
         XCTAssertEqualWithAccuracy(firstAttributes!.frame, CGRect(x: 0, y: 0, width: 320, height: 300), accuracy: CGRect(x: 1, y: 1, width: 1, height: 1))
@@ -320,5 +322,16 @@ class SpotlightLayoutBehaviorTests: BrickFlowLayoutBaseTests {
         collectionView.layoutSubviews()
 
         XCTAssertEqual(collectionView.visibleCells.count, 6)
+    }
+    
+    func testNoInvalitableAttributes() {
+        layoutBehaviorDataSource = FixedSpotlightLayoutBehaviorDataSource(height: nil) // SpotlightLayoutBehaviorDataSource method returns nil
+        behavior = SpotlightLayoutBehavior(dataSource: layoutBehaviorDataSource)
+        behavior.scrollLastBrickToTop = false
+        self.layout.behaviors.insert(behavior)
+        
+        let sectionCount = 3
+        setDataSources(SectionsCollectionViewDataSource(sections: [sectionCount]), brickLayoutDataSource: FixedBrickLayoutDataSource(widthRatio: 1, height: 300))
+        XCTAssertFalse(behavior.hasInvalidatableAttributes())
     }
 }

--- a/Tests/Bricks/GenericBrickTests.swift
+++ b/Tests/Bricks/GenericBrickTests.swift
@@ -65,6 +65,27 @@ class GenericBrickTestUILabel: GenericBrickTests {
     }
 }
 
+class GenericBrickTestHeight: GenericBrickTests, CustomHeightProvider {
+    
+    override func setUp() {
+        super.setUp()
+        // UIView has no intrinsic content size
+        brickCollectionView.setupSingleBrickAndLayout(GenericBrick<UIView>(GenericButtonBrickIdentifier, size: BrickSize(width: .ratio(ratio: 1), height: .fixed(size: 50))) { button, view in
+        })
+        cell = firstCellForIdentifier(GenericButtonBrickIdentifier)
+    }
+    
+    func testHeight() {
+        XCTAssertEqual(CGFloat(0), cell.heightForBrickView(withWidth: 200))
+        cell.customHeightProvider = self
+        XCTAssertEqual(CGFloat(100), cell.heightForBrickView(withWidth: 200))
+    }
+    
+    func customHeight(for view: UIView, constraintedTo width: CGFloat) -> CGFloat {
+        return 100
+    }
+}
+
 class GenericBrickTestUILabelWithEdgeInsets: GenericBrickTests {
 
     override func setUp() {

--- a/Tests/Models/BrickDimensionTests.swift
+++ b/Tests/Models/BrickDimensionTests.swift
@@ -178,8 +178,8 @@ class BrickDimensionTests: XCTestCase {
     func testBrickRangeDimension() {
         setupScreen(isPortrait: true, horizontalSizeClass: .compact, verticalSizeClass: .regular)
         
-        let additionalRangePairs: [RangeDimensionPair] = [(dimension: .ratio(ratio: 0.25), minimumSize: CGFloat(700)),
-                                                          (dimension: .ratio(ratio: 0.5), minimumSize: CGFloat(350))] // Intentionally out of order
+        let additionalRangePairs: [RangeDimensionPair] = [(dimension: .ratio(ratio: 0.5), minimumSize: CGFloat(350)),
+                                                          (dimension: .ratio(ratio: 0.25), minimumSize: CGFloat(700))]
         let regularDimensionRange : BrickDimension = .dimensionRange(default: .ratio(ratio: 1.0), additionalRangePairs: additionalRangePairs)
         XCTAssertEqual(regularDimensionRange.value(for: 320, startingAt: 0), 320)
         setupScreen(isPortrait: true, horizontalSizeClass: .regular, verticalSizeClass: .regular)

--- a/Tests/Utils/DataSources.swift
+++ b/Tests/Utils/DataSources.swift
@@ -241,10 +241,10 @@ class FixedBrickLayoutDataSource: NSObject, BrickLayoutDataSource {
 }
 
 class FixedSpotlightLayoutBehaviorDataSource: SpotlightLayoutBehaviorDataSource {
-    let height: CGFloat
+    let height: CGFloat?
     let identifiers: [String]?
 
-    init(height: CGFloat, identifiers: [String]? = nil) {
+    init(height: CGFloat?, identifiers: [String]? = nil) {
         self.height = height
         self.identifiers = identifiers
     }
@@ -259,9 +259,9 @@ class FixedSpotlightLayoutBehaviorDataSource: SpotlightLayoutBehaviorDataSource 
 }
 
 class FixedCardLayoutBehaviorDataSource: CardLayoutBehaviorDataSource {
-    let height: CGFloat
+    let height: CGFloat?
 
-    init(height: CGFloat) {
+    init(height: CGFloat?) {
         self.height = height
     }
 


### PR DESCRIPTION
Added perfromance improvements by:

- Better checking for context invalidation. If certain behaviors are added to a layout but there are no index paths that would need invalidation by the behaviors, the context shouldn't invalidate.
- Removing excessive sorting when creating BrickRangeDimensions (dimension pairs now have to be provided in minimum size order) 
- Adding a custom height provider for generic brick cells. This will be helpful for generic brick cells that want to use its own size computation rather than rely on auto layout.