### PR TITLE
Removed code that caused edgeInsets to update incorrectly

### DIFF
--- a/Source/Cells/BrickCell.swift
+++ b/Source/Cells/BrickCell.swift
@@ -181,17 +181,12 @@ open class BrickCell: BaseBrickCell {
         return UIEdgeInsetsMake(defaultTopConstraintConstant, defaultLeftConstraintConstant, defaultBottomConstraintConstant, defaultRightConstraintConstant)
     }
 
-    private var didUpdateEdgeInsets: Bool = false
     @objc open dynamic var edgeInsets: UIEdgeInsets = UIEdgeInsets.zero {
         didSet {
-            if edgeInsets == oldValue {
-                return
-            }
             self.topSpaceConstraint?.constant = edgeInsets.top
             self.bottomSpaceConstraint?.constant = edgeInsets.bottom
             self.leftSpaceConstraint?.constant = edgeInsets.left
             self.rightSpaceConstraint?.constant = edgeInsets.right
-            didUpdateEdgeInsets = true
         }
     }
 
@@ -231,14 +226,7 @@ open class BrickCell: BaseBrickCell {
         guard self._brick.height.isEstimate(withValue: nil) else {
             return layoutAttributes
         }
-
-        if !didUpdateEdgeInsets {
-            guard let brickAttributes = layoutAttributes as? BrickLayoutAttributes, brickAttributes.isEstimateSize else {
-                return layoutAttributes
-            }
-        }
-        didUpdateEdgeInsets = false
-
+        
         let preferred = layoutAttributes
 
         // We're inverting the frame because the given frame is already transformed


### PR DESCRIPTION
The conditional that checked whether `edgeInsets == oldValue` caused brickCells to update its edgeInsets incorrectly when the cell's edgeInset was set. When the edgeInset is set sometimes the insets would change to the desired values but sometimes the inset would change to the default value. The deleted code was intended for performance purposes so it does not break the current code.