### PR TITLE
Revert change in PR #164

### DIFF
--- a/Source/Layout/BrickFlowLayout.swift
+++ b/Source/Layout/BrickFlowLayout.swift
@@ -493,8 +493,14 @@ extension BrickFlowLayout: BrickLayoutSectionDataSource {
         var size: CGSize = .zero
         switch type {
         case .brick:
-            let height = _dataSource.brickLayout(self, estimatedHeightForItemAt: indexPath, containedIn: width)
-            size = CGSize(width: width, height: height)
+            // Check if the attributes already had a height. If so, use that height
+            if attributes.frame.height != 0 && _dataSource.brickLayout(self, isEstimatedHeightFor: indexPath) {
+                let height = attributes.frame.size.height
+                size = CGSize(width: width, height: height)
+            } else {
+                let height = _dataSource.brickLayout(self, estimatedHeightForItemAt: indexPath, containedIn: width)
+                size = CGSize(width: width, height: height)
+            }
         case .section(let section):
             let height = _dataSource.brickLayout(self, estimatedHeightForItemAt: indexPath, containedIn: width)
             if height == 0 {


### PR DESCRIPTION
This fixes issue where scrolling in a carousel that used collection brick caused cells above to re-size to a smaller size than what was already calculated