### PR TITLE
Support for Drag and Drop

### DIFF
--- a/BrickKit.xcodeproj/project.pbxproj
+++ b/BrickKit.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		36E718551F71907500ADB252 /* banner1.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 36E718491F71906200ADB252 /* banner1.jpg */; };
 		36E718561F71907500ADB252 /* square0.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 36E7184A1F71906200ADB252 /* square0.jpg */; };
 		36E718571F71907500ADB252 /* square1.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 36E7184B1F71906200ADB252 /* square1.jpg */; };
+		33C0F44A1F77DF40008D14BF /* BrickViewController+DragDrop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33C0F4491F77DF40008D14BF /* BrickViewController+DragDrop.swift */; };
 		4E2882421F2A6BBC0008C157 /* RestrictedBrickSizeTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E2882411F2A6BBC0008C157 /* RestrictedBrickSizeTest.swift */; };
 		4E2882431F2A6BBC0008C157 /* RestrictedBrickSizeTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E2882411F2A6BBC0008C157 /* RestrictedBrickSizeTest.swift */; };
 		4E387C561DAEAB350087820E /* BrickAppearBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93F9B4D11DAD686E00927BE6 /* BrickAppearBehavior.swift */; };
@@ -131,6 +132,7 @@
 		4EDA07D01F2F9FD200BD1D97 /* DummyResizableBrick.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EDA07CD1F2F9FAE00BD1D97 /* DummyResizableBrick.swift */; };
 		4EDA07D21F2FA0E500BD1D97 /* DummyResizableBrick.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4EDA07D11F2FA02800BD1D97 /* DummyResizableBrick.xib */; };
 		4EDA07D41F2FA0ED00BD1D97 /* DummyResizableBrick.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4EDA07CE1F2F9FCD00BD1D97 /* DummyResizableBrick.xib */; };
+		661A82A31F793B400015E594 /* BrickPlaceholderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 661A82A21F793B400015E594 /* BrickPlaceholderCell.swift */; };
 		930054031DA724AD00239A13 /* SetZIndexBehaviorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 930054011DA7242800239A13 /* SetZIndexBehaviorTests.swift */; };
 		930054051DA7D8A000239A13 /* BaseBrickCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 930054041DA7D8A000239A13 /* BaseBrickCellTests.swift */; };
 		9303A6D51DA6E00100502803 /* ButtonBrickTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9303A6D41DA6E00100502803 /* ButtonBrickTests.swift */; };
@@ -289,6 +291,7 @@
 		36E718491F71906200ADB252 /* banner1.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; name = banner1.jpg; path = Assets/banner1.jpg; sourceTree = "<group>"; };
 		36E7184A1F71906200ADB252 /* square0.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; name = square0.jpg; path = Assets/square0.jpg; sourceTree = "<group>"; };
 		36E7184B1F71906200ADB252 /* square1.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; name = square1.jpg; path = Assets/square1.jpg; sourceTree = "<group>"; };
+		33C0F4491F77DF40008D14BF /* BrickViewController+DragDrop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BrickViewController+DragDrop.swift"; sourceTree = "<group>"; };
 		4E2882411F2A6BBC0008C157 /* RestrictedBrickSizeTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestrictedBrickSizeTest.swift; sourceTree = "<group>"; };
 		4E3BD8E01DB5190100541900 /* DummyFocusableBrick.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DummyFocusableBrick.swift; sourceTree = "<group>"; };
 		4E3BD8E31DB51A9700541900 /* DummyFocusableBrick.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = DummyFocusableBrick.xib; sourceTree = "<group>"; };
@@ -316,6 +319,7 @@
 		4EDA07CD1F2F9FAE00BD1D97 /* DummyResizableBrick.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummyResizableBrick.swift; sourceTree = "<group>"; };
 		4EDA07CE1F2F9FCD00BD1D97 /* DummyResizableBrick.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = DummyResizableBrick.xib; sourceTree = "<group>"; };
 		4EDA07D11F2FA02800BD1D97 /* DummyResizableBrick.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = DummyResizableBrick.xib; sourceTree = "<group>"; };
+		661A82A21F793B400015E594 /* BrickPlaceholderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrickPlaceholderCell.swift; sourceTree = "<group>"; };
 		930054011DA7242800239A13 /* SetZIndexBehaviorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SetZIndexBehaviorTests.swift; sourceTree = "<group>"; };
 		930054041DA7D8A000239A13 /* BaseBrickCellTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseBrickCellTests.swift; sourceTree = "<group>"; };
 		9303A6D41DA6E00100502803 /* ButtonBrickTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ButtonBrickTests.swift; sourceTree = "<group>"; };
@@ -759,6 +763,7 @@
 				93D9EBCE1DA4057000D8C87A /* BrickCell.swift */,
 				93D9EBCF1DA4057000D8C87A /* BrickSectionCell.swift */,
 				93D9EBD21DA4057000D8C87A /* ImageDownloader.swift */,
+				661A82A21F793B400015E594 /* BrickPlaceholderCell.swift */,
 			);
 			path = Cells;
 			sourceTree = "<group>";
@@ -807,6 +812,7 @@
 			children = (
 				93D9EBE51DA4057000D8C87A /* BrickCollectionView+BrickLayoutDataSource.swift */,
 				93D9EBE61DA4057000D8C87A /* BrickCollectionView.swift */,
+				33C0F4491F77DF40008D14BF /* BrickViewController+DragDrop.swift */,
 				93D9EBE71DA4057000D8C87A /* BrickViewController.swift */,
 			);
 			path = ViewControllers;
@@ -1305,6 +1311,7 @@
 				93F2CFEA1DDB91D400D5F881 /* BrickZIndexer.swift in Sources */,
 				93739BB61DA454AB00DD4B81 /* LabelBrick.swift in Sources */,
 				93D9EBF21DA4057000D8C87A /* SnapToPointLayoutBehavior.swift in Sources */,
+				661A82A31F793B400015E594 /* BrickPlaceholderCell.swift in Sources */,
 				93D9EC131DA4057000D8C87A /* BrickUtils.swift in Sources */,
 				93D9EC091DA4057000D8C87A /* BrickLayout.swift in Sources */,
 				93D9EC021DA4057000D8C87A /* BrickCell.swift in Sources */,
@@ -1334,6 +1341,7 @@
 				93D9EC171DA4057000D8C87A /* BrickViewController.swift in Sources */,
 				93D9EBED1DA4057000D8C87A /* MaxZIndexLayoutBehavior.swift in Sources */,
 				93D9EC141DA4057000D8C87A /* FatalError.swift in Sources */,
+				33C0F44A1F77DF40008D14BF /* BrickViewController+DragDrop.swift in Sources */,
 				93D9EBEE1DA4057000D8C87A /* MinimumStickyLayoutBehavior.swift in Sources */,
 				931A52F01F0D578C00AB0BDF /* BrickSection.swift in Sources */,
 				93D9EC161DA4057000D8C87A /* BrickCollectionView.swift in Sources */,

--- a/Example/BrickKit-Example.xcodeproj/project.pbxproj
+++ b/Example/BrickKit-Example.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		33C0F44D1F77E801008D14BF /* DragDropBrickViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33C0F44C1F77E801008D14BF /* DragDropBrickViewController.swift */; };
 		4E15F92C1DBA570600BBD363 /* MockTwitterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E15F9231DBA570600BBD363 /* MockTwitterViewController.swift */; };
 		4E15F92D1DBA570600BBD363 /* MockTwitterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E15F9231DBA570600BBD363 /* MockTwitterViewController.swift */; };
 		4E3BD6911DB0097400541900 /* BrickKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4E3BD6851DB0095000541900 /* BrickKit.framework */; };
@@ -265,6 +266,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		33C0F44C1F77E801008D14BF /* DragDropBrickViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragDropBrickViewController.swift; sourceTree = "<group>"; };
 		4E15F9231DBA570600BBD363 /* MockTwitterViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockTwitterViewController.swift; sourceTree = "<group>"; };
 		4E3BD5C71DB008CD00541900 /* BrickApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BrickApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		4E3BD67D1DB0094F00541900 /* BrickKit.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = BrickKit.xcodeproj; path = ../BrickKit.xcodeproj; sourceTree = "<group>"; };
@@ -565,6 +567,7 @@
 				FCD401B51E203D080011173A /* ActivityIndicatorOverrideSource.swift */,
 				93AB641C1E67AA4800395CAA /* IsHiddenBrickViewController.swift */,
 				664A10F51F3359D200DE258B /* PreviewingBrickViewController.swift */,
+				33C0F44C1F77E801008D14BF /* DragDropBrickViewController.swift */,
 			);
 			path = Interactive;
 			sourceTree = "<group>";
@@ -1008,6 +1011,7 @@
 				9357E7F61EDB4CAB0085AFFA /* TwoLabelView.swift in Sources */,
 				4E3BD8441DB1316400541900 /* MultiDimensionBrickViewController.swift in Sources */,
 				4E15F92C1DBA570600BBD363 /* MockTwitterViewController.swift in Sources */,
+				33C0F44D1F77E801008D14BF /* DragDropBrickViewController.swift in Sources */,
 				4E3BD7DE1DB1316400541900 /* SegmentHeaderBrick.swift in Sources */,
 				4E3BD8261DB1316400541900 /* HideSectionsViewController.swift in Sources */,
 				937C9C281F0F2F66008F47CD /* ReverseBrickViewController.swift in Sources */,

--- a/Example/Source/Examples/Interactive/DragDropBrickViewController.swift
+++ b/Example/Source/Examples/Interactive/DragDropBrickViewController.swift
@@ -1,0 +1,105 @@
+//
+//  DragDropBrickViewController.swift
+//  BrickApp-iOS
+//
+//  Created by Aaron Sky on 9/24/17.
+//  Copyright © 2017 Wayfair LLC. All rights reserved.
+//
+
+import UIKit
+import BrickKit
+import MobileCoreServices
+
+extension DragDropBrickViewController: HasTitle {
+    class var brickTitle: String {
+        return "Drag and Drop"
+    }
+    
+    class var subTitle: String {
+        return "Demonstrates UIKit Drag and Drop with bricks"
+    }
+}
+
+class DragDropBrickViewController: BrickViewController {
+    var data = ["dog", "horse", "john", "daniel", "wafer"]
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        self.view.backgroundColor = .brickBackground
+        self.layout.zIndexBehavior = .bottomUp
+        self.setSection(buildLayout())
+    }
+    
+    func buildLayout() -> BrickSection {
+        let brick = GenericBrick<UILabel>(BrickIdentifiers.repeatLabel, width: .ratio(ratio: 0.5), height: .fixed(size: 50), backgroundColor: .brickGray1)
+        { label, cell in
+            label.font = .brickLightFont(size: 16)
+            label.configure(textColor: UIColor.brickGray1.complemetaryColor)
+            label.textAlignment = .center
+            cell.edgeInsets = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
+            if #available(iOS 11.0, *) {
+                label.text = self.data[cell.index]
+            } else {
+                label.text = "iOS 11 is required for this demo"
+            }
+        }
+        if #available(iOS 11.0, *) {
+            brick.repeatCount = self.data.count
+            brick.dragDropDelegate = self
+        } else {
+            brick.repeatCount = 1
+        }
+        let section = BrickSection(bricks: [brick],
+                                   inset: Constants.brickInset,
+                                   edgeInsets: UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10),
+                                   alignment: BrickAlignment(horizontal: .center, vertical: .top))
+        return section
+    }
+}
+
+@available(iOS 11.0, *)
+extension DragDropBrickViewController: BrickDragDropDelegate {
+    var itemProviderType: NSItemProviderReading.Type {
+        return NSString.self
+    }
+    
+    func dragItems(for session: UIDragSession, at indexPath: IndexPath) -> [UIDragItem] {
+        let dataElement = self.data[indexPath.row]
+        let dataBinary = dataElement.data(using: .utf8)
+        let itemProvider = NSItemProvider()
+        itemProvider.registerDataRepresentation(forTypeIdentifier: kUTTypePlainText as String, visibility: .all) { completion in
+            completion(dataBinary, nil)
+            return nil
+        }
+        let dragItem = UIDragItem(itemProvider: itemProvider)
+        dragItem.localObject = dataElement
+        return [dragItem]
+    }
+
+    func previewParameters(for view: UICollectionViewCell, at indexPath: IndexPath) -> UIDragPreviewParameters? {
+        return nil
+    }
+
+    func canHandle(_ session: UIDropSession) -> Bool {
+        return session.hasItemsConforming(toTypeIdentifiers: NSString.readableTypeIdentifiersForItemProvider)
+    }
+    
+    func willDrop(_ item: Any?) -> Bool {
+        guard let item = item as? String, !self.data.contains(item) else {
+            return false
+        }
+        return true
+    }
+
+    func drop(_ item: Any?, to destinationIndex: Int, from sourceIndex: Int?) {
+        guard let item = item as? String else {
+            return
+        }
+        if let sourceIndex = sourceIndex {
+            self.data.remove(at: sourceIndex)
+        }
+        self.data.insert(item, at: destinationIndex)
+    }
+}
+

--- a/Example/Source/Examples/Interactive/InsertBrickViewController.swift
+++ b/Example/Source/Examples/Interactive/InsertBrickViewController.swift
@@ -150,9 +150,8 @@ extension InsertBrickViewController: BrickRepeatCountDataSource {
     func repeatCount(for identifier: String, with collectionIndex: Int, collectionIdentifier: String) -> Int {
         if identifier == BrickIdentifiers.repeatLabel {
             return data.count
-        } else {
-            return 1
         }
+        return 1
     }
 }
 

--- a/Example/Source/Navigation/NavigationDataSource.swift
+++ b/Example/Source/Navigation/NavigationDataSource.swift
@@ -121,6 +121,7 @@ class NavigationDataSource {
         InvalidateHeightViewController.self,
         InteractiveAlignViewController.self,
         PreviewingBrickViewController.self,
+        DragDropBrickViewController.self
         ])
     #else
     var InteractiveExamples = NavigationItem(title: "Interactive", subTitle: "Interactive Examples", viewControllers: [

--- a/Source/Cells/BrickCell.swift
+++ b/Source/Cells/BrickCell.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-// Mark: - Resizeable cells
+// MARK: - Resizeable cells
 
 public protocol AsynchronousResizableCell: class  {
     weak var resizeDelegate: AsynchronousResizableDelegate? { get set }

--- a/Source/Cells/BrickPlaceholderCell.swift
+++ b/Source/Cells/BrickPlaceholderCell.swift
@@ -1,0 +1,50 @@
+//
+//  BrickPlaceholderCell.swift
+//  BrickKit-iOS
+//
+//  Created by Aaron Sky on 9/25/17.
+//  Copyright © 2017 Wayfair. All rights reserved.
+//
+
+class BrickPlaceholderCell: BaseBrickCell {
+    @IBOutlet private weak var progressView: UIProgressView!
+
+    /// Stores a progress that is observed using KVO to update the progress view.
+    private var progress: Progress? {
+        willSet(newProgress) {
+            progress?.removeObserver(self, forKeyPath: #keyPath(Progress.fractionCompleted))
+        }
+        didSet {
+            if let progress = progress {
+                progressView.setProgress(Float(progress.fractionCompleted), animated: false)
+                // TODO: Update to Swift 4 key path syntax
+                progress.addObserver(self, forKeyPath: #keyPath(Progress.fractionCompleted), options: [.initial, .new], context: nil)
+            }
+        }
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        self.isUserInteractionEnabled = false
+        self.contentView.isUserInteractionEnabled = false
+    }
+
+    func configure(with progress: Progress) {
+        self.progress = progress
+    }
+
+    override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
+        if object as? Progress == progress && keyPath == #keyPath(Progress.fractionCompleted) {
+            if let fractionCompleted = change?[.newKey] as? Double {
+                DispatchQueue.main.async {
+                    // Update the progress view to display the new fractionCompleted value from the progress.
+                    self.progressView.setProgress(Float(fractionCompleted), animated: true)
+                }
+            }
+        }
+    }
+
+    deinit {
+        progress = nil
+    }
+}

--- a/Source/Cells/ImageDownloader.swift
+++ b/Source/Cells/ImageDownloader.swift
@@ -23,7 +23,7 @@ private func _downloadImageAndSet(_ imageDownloader: ImageDownloader, on imageVi
     }
 }
 
-// Mark: - Image Downloader
+// MARK: - Image Downloader
 public protocol ImageDownloader: class {
     func downloadImage(with imageURL: URL, onCompletion completionHandler: @escaping ((_ image: UIImage, _ url: URL) -> Void))
     func downloadImageAndSet(on imageView: UIImageView, with imageURL: URL, onCompletion completionHandler: @escaping ((_ image: UIImage, _ url: URL) -> Void))

--- a/Source/Layout/BrickFlowLayout.swift
+++ b/Source/Layout/BrickFlowLayout.swift
@@ -46,7 +46,7 @@ open class BrickFlowLayout: UICollectionViewLayout, BrickLayout {
     var dirtyMap: [Int: Int] = [:]
     var dirtyIndexPaths: [IndexPath] = []
 
-    // Mark: - Public members
+    // MARK: - Public members
 
     open override var description: String {
         return super.description + " CollectionBrick: \(isInCollectionBrick)"
@@ -85,7 +85,7 @@ open class BrickFlowLayout: UICollectionViewLayout, BrickLayout {
     /// Width Ratio
     open var widthRatio: CGFloat = 1
 
-    // Mark: - Private members
+    // MARK: - Private members
 
     /// Content width that was used to calculate the layout
     fileprivate var contentWidth: CGFloat?

--- a/Source/Layout/BrickZIndexer.swift
+++ b/Source/Layout/BrickZIndexer.swift
@@ -136,7 +136,7 @@ public enum BrickLayoutZIndexBehavior {
 
 }
 
-// Mark: - SectionRange
+// MARK: - SectionRange
 
 /// Container object that holds a range and the start zIndex
 struct SectionRange {
@@ -231,7 +231,7 @@ class BrickZIndexer {
         return zIndexBehavior.zIndexFromRanges(ranges, index: indexPath.item) - (withOffset ? maxZIndex : 0)
     }
 
-// Mark: - Private methods
+// MARK: - Private methods
 
     /// Update the count of the ranges to the parent section(s) of an inserted section
     fileprivate func updateRanges(to section: Int, with numberOfItems: Int, dataSource: BrickLayoutDataSource, layout: BrickFlowLayout) {

--- a/Source/Models/Brick.swift
+++ b/Source/Models/Brick.swift
@@ -22,10 +22,54 @@ public protocol BrickPreviewingDelegate: class {
     func commit(viewController: UIViewController)
 }
 
+@available(iOS 11.0, *)
+public protocol BrickDragDropDelegate: class {
+    @available(iOS 11.0, *)
+    var itemProviderType: NSItemProviderReading.Type { get }
+    
+    @available(iOS 11.0, *)
+    func dragItems(for session: UIDragSession, at indexPath: IndexPath) -> [UIDragItem]
+    
+    @available(iOS 11.0, *)
+    func previewParameters(for view: UICollectionViewCell, at indexPath: IndexPath) -> UIDragPreviewParameters?
+    
+    @available(iOS 11.0, *)
+    func canHandle(_ session: UIDropSession) -> Bool
+
+    @available(iOS 11.0, *)
+    func willDrop(_ item: Any?) -> Bool
+
+    @available(iOS 11.0, *)
+    func drop(_ item: Any?, to destinationIndex: Int, from sourceIndex: Int?)
+}
+
+@available(iOS 11.0, *)
+extension BrickDragDropDelegate {
+    func dragItems(for session: UIDragSession, at indexPath: IndexPath) -> [UIDragItem] {
+        return []
+    }
+    
+    func previewParameters(for view: UICollectionViewCell, at indexPath: IndexPath) -> UIDragPreviewParameters? {
+        return nil
+    }
+    
+    func canHandle(_ session: UIDropSession) -> Bool {
+        return false
+    }
+    
+    func willDrop(_ item: Any?) -> Bool {
+        return false
+    }
+
+    func drop(_ item: Any?, to destinationIndex: Int, from sourceIndex: Int? = nil) {
+        // no-op
+    }
+}
+
 /// A Brick is the model representation of a BrickCell in a BrickCollectionView
 open class Brick: CustomStringConvertible {
 
-    // Mark: - Public members
+    // MARK: - Public members
 
     /// Identifier of the brick. Defaults to empty string
     open let identifier: String
@@ -83,6 +127,19 @@ open class Brick: CustomStringConvertible {
     
     /// Delegate that handles behavior for how to present other view controllers using 3D Touch
     open weak var previewingDelegate: BrickPreviewingDelegate?
+    
+    private weak var _dragDropDelegate: AnyObject?
+    @available(iOS 11.0, *)
+    open weak var dragDropDelegate: BrickDragDropDelegate? {
+        get {
+            return _dragDropDelegate as? BrickDragDropDelegate
+        }
+        set(newDelegate) {
+            _dragDropDelegate = newDelegate
+        }
+    }
+    
+    
     /// Initialize a Brick
     ///
     /// - parameter identifier:      Identifier of the brick. Defaults to empty string
@@ -103,7 +160,7 @@ open class Brick: CustomStringConvertible {
         self.accessibilityIdentifier = identifier
     }
 
-    // Mark: - Internal
+    // MARK: - Internal
 
     /// Keeps track of the counts per collection info
     internal var counts: [CollectionInfo:Int] = [:]
@@ -113,7 +170,7 @@ open class Brick: CustomStringConvertible {
         return counts[collection] ?? self.repeatCount
     }
 
-    // Mark: - Loading nibs/cells
+    // MARK: - Loading nibs/cells
 
     /// Instance variable: Name of the nib that should be used to load this brick's cell
     open var nibName: String {
@@ -142,7 +199,7 @@ open class Brick: CustomStringConvertible {
         return Bundle(for: self)
     }
 
-    // Mark: - CustomStringConvertible
+    // MARK: - CustomStringConvertible
 
     open var description: String {
         return descriptionWithIndentationLevel(0)

--- a/Source/Models/BrickSection.swift
+++ b/Source/Models/BrickSection.swift
@@ -115,7 +115,7 @@ open class BrickSection: Brick {
         }
     }
 
-    // Mark: - CustomStringConvertible
+    // MARK: - CustomStringConvertible
 
     /// Convenience method to show description with an indentation
     override internal func descriptionWithIndentationLevel(_ indentationLevel: Int) -> String {
@@ -130,5 +130,20 @@ open class BrickSection: Brick {
         description += brickDescription
         
         return description
+    }
+}
+
+@available(iOS 11.0, *)
+extension BrickSection {
+    func canBricksHandle(_ session: UIDropSession) -> Bool {
+        for brick in bricks {
+            guard let dropDelegate = brick.dragDropDelegate else {
+                continue
+            }
+            if dropDelegate.canHandle(session) {
+                return true
+            }
+        }
+        return false
     }
 }

--- a/Source/ViewControllers/BrickViewController+DragDrop.swift
+++ b/Source/ViewControllers/BrickViewController+DragDrop.swift
@@ -1,0 +1,188 @@
+//
+//  File.swift
+//  BrickKit
+//
+//  Created by Aaron Sky on 9/24/17.
+//  Copyright © 2017 Wayfair. All rights reserved.
+//
+
+import Foundation
+
+@available(iOS 11.0, *)
+extension BrickViewController: UICollectionViewDragDelegate {
+    @available(iOS 11.0, *)
+    public func collectionView(_ collectionView: UICollectionView, itemsForBeginning session: UIDragSession, at indexPath: IndexPath) -> [UIDragItem] {
+        guard let collectionView = collectionView as? BrickCollectionView,
+            indexPath.section != 0,
+            let brickDragDelegate = collectionView.brick(at: indexPath).dragDropDelegate else {
+            return []
+        }
+        return brickDragDelegate.dragItems(for: session, at: indexPath)
+    }
+
+    @available(iOS 11.0, *)
+    public func collectionView(_ collectionView: UICollectionView, itemsForAddingTo session: UIDragSession, at indexPath: IndexPath, point: CGPoint) -> [UIDragItem] {
+        guard let collectionView = collectionView as? BrickCollectionView,
+            indexPath.section != 0,
+            let brickDragDelegate = collectionView.brick(at: indexPath).dragDropDelegate else {
+            return []
+        }
+        return brickDragDelegate.dragItems(for: session, at: indexPath)
+    }
+    
+    @available(iOS 11.0, *)
+    public func collectionView(_ collectionView: UICollectionView, dragPreviewParametersForItemAt indexPath: IndexPath) -> UIDragPreviewParameters? {
+        guard let collectionView = collectionView as? BrickCollectionView,
+            indexPath.section != 0,
+            let brickDragDelegate = collectionView.brick(at: indexPath).dragDropDelegate,
+            let view = collectionView.cellForItem(at: indexPath) else {
+            return nil
+        }
+        return brickDragDelegate.previewParameters(for: view, at: indexPath)
+    }
+    
+    @available(iOS 11.0, *)
+    public func collectionView(_ collectionView: UICollectionView, dragSessionWillBegin session: UIDragSession) {
+        // no-op
+    }
+    
+    @available(iOS 11.0, *)
+    public func collectionView(_ collectionView: UICollectionView, dragSessionDidEnd session: UIDragSession) {
+        // no-op
+    }
+}
+
+@available(iOS 11.0, *)
+extension BrickViewController: UICollectionViewDropDelegate {
+    @available(iOS 11.0, *)
+    public func collectionView(_ collectionView: UICollectionView, canHandle session: UIDropSession) -> Bool {
+        guard let collectionView = collectionView as? BrickCollectionView else {
+            return false
+        }
+        return collectionView.section.canBricksHandle(session)
+    }
+    
+    @available(iOS 11.0, *)
+    public func collectionView(_ collectionView: UICollectionView, dropSessionDidUpdate session: UIDropSession, withDestinationIndexPath destinationIndexPath: IndexPath?) -> UICollectionViewDropProposal {
+        if destinationIndexPath?.section == 0 {
+            return UICollectionViewDropProposal(operation: .cancel)
+        } else if session.localDragSession != nil {
+            return UICollectionViewDropProposal(operation: .move, intent: .insertAtDestinationIndexPath)
+        }
+        return UICollectionViewDropProposal(operation: .copy, intent: .insertAtDestinationIndexPath)
+    }
+    
+    @available(iOS 11.0, *)
+    public func collectionView(_ collectionView: UICollectionView, performDropWith coordinator: UICollectionViewDropCoordinator) {
+        let destinationIndexPath: IndexPath
+        if let indexPath = coordinator.destinationIndexPath, indexPath.section != 0 {
+            destinationIndexPath = indexPath
+        } else {
+            let section = collectionView.numberOfSections - 1
+            let row = collectionView.numberOfItems(inSection: section) - 1
+            destinationIndexPath = IndexPath(row: row, section: section)
+            if destinationIndexPath.section <= 0 {
+                return
+            }
+        }
+        
+        if coordinator.proposal.operation == .copy {
+            self.loadAndInsertItems(at: destinationIndexPath, with: coordinator)
+        } else if coordinator.proposal.operation == .move {
+            let items = coordinator.items
+            if items.contains(where: { $0.sourceIndexPath != nil }) && items.count == 1,
+                let item = items.first {
+                // Reordering a single item from this collection view.
+                self.reorder(item, to: destinationIndexPath, with: coordinator)
+            } else {
+                // Moving items from somewhere else in this app.
+                self.moveItems(to: destinationIndexPath, with: coordinator)
+            }
+        }
+    }
+
+    @available(iOS 11.0, *)
+    public func collectionView(_ collectionView: UICollectionView, dropPreviewParametersForItemAt indexPath: IndexPath) -> UIDragPreviewParameters? {
+        guard let collectionView = collectionView as? BrickCollectionView,
+            let brickDragDelegate = collectionView.brick(at: indexPath).dragDropDelegate,
+            let view = collectionView.cellForItem(at: indexPath) else {
+                return nil
+        }
+        return brickDragDelegate.previewParameters(for: view, at: indexPath)
+    }
+    
+    @available(iOS 11.0, *)
+    private func loadAndInsertItems(at destinationIndexPath: IndexPath, with coordinator: UICollectionViewDropCoordinator) {
+        guard let brick = Optional.some(self.brickCollectionView.brick(at: destinationIndexPath)),
+            let delegate = brick.dragDropDelegate else {
+                return
+        }
+        coordinator.items.forEach { dropItem in
+            let dragItem = dropItem.dragItem
+            let itemProvider = dragItem.itemProvider
+            guard itemProvider.canLoadObject(ofClass: delegate.itemProviderType) else {
+                return
+            }
+
+            var placeholderContext: UICollectionViewDropPlaceholderContext? = nil
+            // Do I need [weak self] here?
+            let progress = itemProvider.loadObject(ofClass: delegate.itemProviderType) { optionalObject, error in
+                DispatchQueue.main.async {
+                    guard let item = optionalObject,
+                        delegate.willDrop(item) else {
+                        placeholderContext?.deletePlaceholder()
+                        return
+                    }
+                    placeholderContext?.commitInsertion { insertionIndexPath in
+                        delegate.drop(item, to: insertionIndexPath.item, from: nil)
+                    }
+                }
+            }
+            let placeholder = UICollectionViewDropPlaceholder(insertionIndexPath: destinationIndexPath, reuseIdentifier: brick.identifier)
+            placeholder.cellUpdateHandler = { cell in
+                guard let placeholderCell = cell as? BrickPlaceholderCell else {
+                    return
+                }
+                placeholderCell.configure(with: progress)
+            }
+            placeholderContext = coordinator.drop(dragItem, to: placeholder)
+        }
+        coordinator.session.progressIndicatorStyle = .none
+    }
+
+    @available(iOS 11.0, *)
+    private func reorder(_ item: UICollectionViewDropItem, to destinationIndexPath: IndexPath, with coordinator: UICollectionViewDropCoordinator) {
+        guard let collectionView = collectionView as? BrickCollectionView,
+            let delegate = collectionView.brick(at: destinationIndexPath).dragDropDelegate,
+            let sourceIndexPath = item.sourceIndexPath else {
+                return
+        }
+        collectionView.performBatchUpdates({
+            delegate.drop(item.dragItem.localObject, to: destinationIndexPath.item, from: sourceIndexPath.item)
+            collectionView.deleteItems(at: [sourceIndexPath])
+            collectionView.insertItems(at: [destinationIndexPath])
+        })
+        coordinator.drop(item.dragItem, toItemAt: destinationIndexPath)
+    }
+
+    @available(iOS 11.0, *)
+    private func moveItems(to destinationIndexPath: IndexPath, with coordinator: UICollectionViewDropCoordinator) {
+        guard let collectionView = collectionView as? BrickCollectionView,
+            let delegate = collectionView.brick(at: destinationIndexPath).dragDropDelegate else {
+            return
+        }
+        var skipped = 0
+        for (offset, dropItem) in coordinator.items.enumerated() {
+            guard let item = dropItem.dragItem.localObject, delegate.willDrop(item) else {
+                skipped += 1
+                continue
+            }
+            let insertionIndexPath = IndexPath(item: destinationIndexPath.item + offset - skipped, section: destinationIndexPath.section)
+            collectionView.performBatchUpdates({
+                delegate.drop(item, to: insertionIndexPath.item, from: nil)
+                collectionView.insertItems(at: [insertionIndexPath])
+            })
+            coordinator.drop(dropItem.dragItem, toItemAt: insertionIndexPath)
+        }
+    }
+}

--- a/Source/ViewControllers/BrickViewController.swift
+++ b/Source/ViewControllers/BrickViewController.swift
@@ -95,6 +95,11 @@ open class BrickViewController: UIViewController, UICollectionViewDelegate {
 
             self.collectionView = collectionView
             self.collectionView?.delegate = self
+            
+            if #available(iOS 11.0, *) {
+                self.collectionView?.dragDelegate = self
+                self.collectionView?.dropDelegate = self
+            }
         }
     }
     


### PR DESCRIPTION
### This pull request is a Work In Progress and should not be merged until otherwise noted!!

This PR introduces drag and drop support to BrickKit. 

Bricks that should be considered eligible for drag and/or drop should provide a delegate for `Brick#dragDropDelegate`. To opt-in to drag, return a `[UIDragItem]` in `BrickDragDropDelegate#dragItems(for:at:)`. To opt-in to drop, return a Bool in `BrickDragDropDelegate#canHandle(_:)` affirming whether the provided `UIDropSession` has any objects that conform to your brick's supported UTIs, and implement the `BrickDragDropDelegate#willDrop(_)` and `BrickDragDropDelegate#drop(_:to:from:)` handlers. For more information, see the `DragDropBrickViewController` example, as well as [Apple's documentation on Drag and Drop in Collection Views](https://developer.apple.com/documentation/uikit/views_and_controls/collection_views/supporting_drag_and_drop_in_collection_views).

I have put this PR up here despite its state of completion to kickstart discussion about this feature, as well as provide advice on how BrickLayouts work. 

### Current list of to-dos:

- [ ] Fix current blocking crashers
    - [ ] Sample app crashes while attempting to reorder layout while previous drop has not completed
    - [ ] Sample app crashes while attempting to reorder layout to accommodate new cells
- [ ] Document all new methods and protocols
- [ ] Implement drag and drop in other example controllers to demonstrate drag and drop between collection views within the same app
- [ ] Write lots of unit tests