### PR TITLE
Background colors should default to .clear not .white.

### DIFF
--- a/Source/Bricks/Button/ButtonBrick.swift
+++ b/Source/Bricks/Button/ButtonBrick.swift
@@ -164,7 +164,7 @@ open class ButtonBrickCell: GenericBrickCell, Bricklike {
         self.isHidden = false
         self.accessoryView = nil
         self.backgroundView = nil
-        self.backgroundColor = .white
+        self.backgroundColor = .clear
 
         self.button.isHidden = false
         self.button.setImage(nil, for: .normal)

--- a/Source/Bricks/Label/LabelBrick.swift
+++ b/Source/Bricks/Label/LabelBrick.swift
@@ -189,7 +189,7 @@ open class LabelBrickCell: GenericBrickCell, Bricklike {
 
     override open func prepareForReuse() {
         super.prepareForReuse()
-        self.backgroundColor = .white
+        self.backgroundColor = .clear
         self.backgroundView = nil
         self.isHidden = false
         self.edgeInsets = UIEdgeInsets.zero
@@ -201,7 +201,7 @@ open class LabelBrickCell: GenericBrickCell, Bricklike {
         self.label.numberOfLines = 0
         self.label.textColor = .black
         self.label.isHidden = false
-        self.label.backgroundColor = .white
+        self.label.backgroundColor = .clear
 
         self.horizontalRuleLeft = nil
         self.horizontalRuleRight = nil

--- a/Tests/Bricks/ButtonBrickTests.swift
+++ b/Tests/Bricks/ButtonBrickTests.swift
@@ -312,7 +312,7 @@ class ButtonBrickTests: XCTestCase {
 
         XCTAssertEqual(cell?.button.titleLabel?.textAlignment, .natural)
         XCTAssertEqual(cell?.button.titleLabel?.numberOfLines, 0)
-        XCTAssertEqual(cell?.backgroundColor, .white)
+        XCTAssertEqual(cell?.backgroundColor, .clear)
         XCTAssertNil(cell?.accessoryView)
         XCTAssertNil(cell?.button.titleLabel?.backgroundColor)
         XCTAssertNil(cell?.button.titleLabel?.attributedText)

--- a/Tests/Bricks/LabelBrickTests.swift
+++ b/Tests/Bricks/LabelBrickTests.swift
@@ -314,8 +314,8 @@ class LabelBrickTests: XCTestCase {
 
         XCTAssertEqual(cell?.label.textAlignment, .natural)
         XCTAssertEqual(cell?.label.numberOfLines, 0)
-        XCTAssertEqual(cell?.label.backgroundColor, .white)
-        XCTAssertEqual(cell?.backgroundColor, .white)
+        XCTAssertEqual(cell?.label.backgroundColor, .clear)
+        XCTAssertEqual(cell?.backgroundColor, .clear)
         XCTAssertNil(cell?.accessoryView)
         XCTAssertNil(cell?.label.attributedText)
         XCTAssertNil(cell?.label.text)


### PR DESCRIPTION
Slight change to the `prepareForReuse` functions for `LabelBrick` and `ButtonBrick`. The background colors should default to .clear instead of .white.