### PR TITLE
Attempt to fix a crash appearing in Crashlytics (couldn’t reproduce c…

### DIFF
--- a/Source/Layout/BrickFlowLayout.swift
+++ b/Source/Layout/BrickFlowLayout.swift
@@ -302,11 +302,9 @@ extension BrickFlowLayout {
 
     func updateDirtyBricks(updatedAttributes: @escaping OnAttributesUpdatedHandler) {
         for (section, item) in dirtyMap {
-            // This can be unwrapped safely
-            // because the sections that are in the dirtyMap should be there
-            let layoutSection = sections![section]!
-            layoutSection.createOrUpdateCells(from: item, invalidate: false, updatedAttributes: updatedAttributes)
-            if let sectionAttributes = layoutSection.sectionAttributes {
+            let layoutSection = sections?[section]
+            layoutSection?.createOrUpdateCells(from: item, invalidate: false, updatedAttributes: updatedAttributes)
+            if let sectionAttributes = layoutSection?.sectionAttributes {
                 invalidateHeight(for: sectionAttributes.indexPath, updatedAttributes: updatedAttributes)
             }
         }


### PR DESCRIPTION
(couldn’t reproduce crash). It's a bad exec access (could be a force unwrap).

The stacktrack trace called updateDirtyBricks() right before the crash, so hopefully this is related, however I couldn't determine how dirtyMap would ever get out of sync with self.sections