### PR TITLE
Updated the UpdateFrameListener function to pass the GenericBrickCell.

### DIFF
--- a/Tests/Cells/FrameCalculationTests.swift
+++ b/Tests/Cells/FrameCalculationTests.swift
@@ -70,14 +70,40 @@ class FrameCalculationTests: XCTestCase {
         waitForExpectations(timeout: 1.0, handler: nil)
     }
 
+    func testGenericBrickUIImageViewFrameListener() {
+        let expect = expectation(description:"Expect framesDidLayout to get called")
+        let mockFrameChangeListener = MockFrameListener()
+
+        let genericBrick = GenericBrick<UIImageView>("FrameInfo", size: BrickSize(width: .fixed(size: 50), height: .fixed(size: 50))) { (view, cell) in
+        }
+
+        genericBrick.frameLayoutListener = mockFrameChangeListener
+
+        brickView.setupSingleBrickAndLayout(
+            genericBrick
+        )
+        let indexPath = brickView.indexPathsForBricksWithIdentifier("FrameInfo").first!
+        let cell = brickView.cellForItem(at: indexPath) as! GenericBrickCell
+        cell.layoutIfNeeded()
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            XCTAssertTrue(mockFrameChangeListener.didUpdateFramesCalled)
+            expect.fulfill()
+        }
+        waitForExpectations(timeout: 1.0, handler: nil)
+    }
 }
 
-class TestView: UIView {
+class TestView: UIView, FrameLayoutListener {
     var didUpdateFramesCalled: Bool = false
+    func didLayoutFrames(cell: GenericBrickCell) {
+        didUpdateFramesCalled = true
+    }
 }
 
-extension TestView: UpdateFramesListener {
-    func didUpdateFrames() {
+class MockFrameListener: FrameLayoutListener {
+    var didUpdateFramesCalled: Bool = false
+    func didLayoutFrames(cell: GenericBrickCell) {
         didUpdateFramesCalled = true
     }
 }


### PR DESCRIPTION
This will allow the function to access _brick.index and cell.genericContentView, which can be used to make content changes later in the layout cycle, convenient when loading images based on the size of the UIImageView.