### PR TITLE
Stability, Layout, and Logging Enhancements; Added Support for Legacy Edge Insets Functionality

### DIFF
--- a/BrickKit.xcodeproj/project.pbxproj
+++ b/BrickKit.xcodeproj/project.pbxproj
@@ -385,7 +385,7 @@
 		93D9EBE21DA4057000D8C87A /* BrickUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BrickUtils.swift; sourceTree = "<group>"; };
 		93D9EBE31DA4057000D8C87A /* FatalError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FatalError.swift; sourceTree = "<group>"; };
 		93D9EBE51DA4057000D8C87A /* BrickCollectionView+BrickLayoutDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "BrickCollectionView+BrickLayoutDataSource.swift"; sourceTree = "<group>"; };
-		93D9EBE61DA4057000D8C87A /* BrickCollectionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = BrickCollectionView.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		93D9EBE61DA4057000D8C87A /* BrickCollectionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = BrickCollectionView.swift; sourceTree = "<group>"; };
 		93D9EBE71DA4057000D8C87A /* BrickViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BrickViewController.swift; sourceTree = "<group>"; };
 		93D9EC1A1DA4057900D8C87A /* CardLayoutBehaviorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardLayoutBehaviorTests.swift; sourceTree = "<group>"; };
 		93D9EC1C1DA4057900D8C87A /* HideLayoutBehaviorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HideLayoutBehaviorTests.swift; sourceTree = "<group>"; };

--- a/Source/Cells/BrickCell.swift
+++ b/Source/Cells/BrickCell.swift
@@ -181,17 +181,23 @@ open class BrickCell: BaseBrickCell {
         return UIEdgeInsetsMake(defaultTopConstraintConstant, defaultLeftConstraintConstant, defaultBottomConstraintConstant, defaultRightConstraintConstant)
     }
 
+    open var needsLegacyEdgeInsetFunctionality = false
     private var didUpdateEdgeInsets: Bool = false
     @objc open dynamic var edgeInsets: UIEdgeInsets = UIEdgeInsets.zero {
         didSet {
-            if edgeInsets == oldValue {
+
+            if edgeInsets == oldValue && needsLegacyEdgeInsetFunctionality {
                 return
             }
+
             self.topSpaceConstraint?.constant = edgeInsets.top
             self.bottomSpaceConstraint?.constant = edgeInsets.bottom
             self.leftSpaceConstraint?.constant = edgeInsets.left
             self.rightSpaceConstraint?.constant = edgeInsets.right
-            didUpdateEdgeInsets = true
+
+            if needsLegacyEdgeInsetFunctionality {
+                didUpdateEdgeInsets = true
+            }
         }
     }
 
@@ -232,13 +238,15 @@ open class BrickCell: BaseBrickCell {
             return layoutAttributes
         }
 
-        if !didUpdateEdgeInsets {
-            guard let brickAttributes = layoutAttributes as? BrickLayoutAttributes, brickAttributes.isEstimateSize else {
-                return layoutAttributes
+        if needsLegacyEdgeInsetFunctionality {
+            if !didUpdateEdgeInsets {
+                guard let brickAttributes = layoutAttributes as? BrickLayoutAttributes, brickAttributes.isEstimateSize else {
+                    return layoutAttributes
+                }
             }
+            didUpdateEdgeInsets = false
         }
-        didUpdateEdgeInsets = false
-
+        
         let preferred = layoutAttributes
 
         // We're inverting the frame because the given frame is already transformed

--- a/Source/Layout/BrickFlowLayout.swift
+++ b/Source/Layout/BrickFlowLayout.swift
@@ -160,8 +160,13 @@ open class BrickFlowLayout: UICollectionViewLayout, BrickLayout {
 
                 var updated = false
                 for section in currentSections {
+                    // For deletion cases, we don't want to recalculate brick layaout sections for indexes
+                    // that no longer exist in the collection view.
+                    let sectionCount = _collectionView.numberOfItems(inSection: section.sectionIndex)
                     updateSection(section, updatedAttributes: updateAttributes, action: {
-                        updated = section.continueCalculatingCells() || updated
+                        if section.numberOfItems <= sectionCount {
+                            updated = section.continueCalculatingCells() || updated
+                        }
                     })
                 }
 

--- a/Source/Layout/BrickLayoutSection.swift
+++ b/Source/Layout/BrickLayoutSection.swift
@@ -330,13 +330,15 @@ internal class BrickLayoutSection {
 
         let numberOfItems = self.numberOfItems
 
-        for index in firstIndex..<numberOfItems {
-            // Create or Update an attribute at an index. If returned true, continue calculating. If not, break
-            if !createOrUpdateAttribute(at: index, with: dataSource, x: &x, y: &y, maxY: &maxY, force: false, invalidate: invalidate, frameOfInterest: frameOfInterest, updatedAttributes: updatedAttributes) {
-                break
+        if firstIndex < numberOfItems {
+            for index in firstIndex..<numberOfItems {
+                // Create or Update an attribute at an index. If returned true, continue calculating. If not, break
+                if !createOrUpdateAttribute(at: index, with: dataSource, x: &x, y: &y, maxY: &maxY, force: false, invalidate: invalidate, frameOfInterest: frameOfInterest, updatedAttributes: updatedAttributes) {
+                    break
+                }
             }
         }
-
+        
         // If rows need to be aligned, make sure the previous lines are checked
         handleRow(for: attributes.count - 1, maxHeight: maxY - y, updatedAttributes: updatedAttributes)
 

--- a/Source/ViewControllers/BrickCollectionView.swift
+++ b/Source/ViewControllers/BrickCollectionView.swift
@@ -267,7 +267,6 @@ open class BrickCollectionView: UICollectionView {
         super.reloadData()
     }
 
-
     open override func performBatchUpdates(_ updates: (() -> Void)?, completion: ((Bool) -> Void)? = nil) {
         BrickLogger.logVerbose("Will perform batch updates.")
         super.performBatchUpdates(updates, completion: { completed in

--- a/Source/ViewControllers/BrickCollectionView.swift
+++ b/Source/ViewControllers/BrickCollectionView.swift
@@ -564,7 +564,7 @@ open class BrickCollectionView: UICollectionView {
         var removedIndexPaths = [IndexPath]()
         var reloadIndexPaths = [IndexPath]()
         let sectionsToReload = NSMutableIndexSet()
-
+        BrickLogger.logVerbose("Reload Bricks with identifiers: \(identifiers).")
         for identifier in identifiers {
             let indexPaths = self.section.indexPathsForBricksWithIdentifier(identifier, in: collectionInfo)
             for indexPath in indexPaths {
@@ -581,10 +581,6 @@ open class BrickCollectionView: UICollectionView {
                     brickCell.reloadContent()
                 }
             }
-        }
-
-        if !shouldReloadCell {
-            return
         }
 
         if !insertedIndexPaths.isEmpty {
@@ -637,7 +633,14 @@ open class BrickCollectionView: UICollectionView {
     /// - returns: A dictionary with the section as the key and the value is the change count
     fileprivate func reloadSectionWithIdentifier(_ identifier: String) -> [Int: Int] {
         let oldCounts = self.section.currentSectionCounts(in: collectionInfo)
-        self.section.invalidateCounts(in: collectionInfo)
+        
+        if let matchingIndex = self.indexPathsForBricksWithIdentifier(identifier).first,
+            let brickSectionCell = cellForItem(at: matchingIndex) as? BrickSectionCell,
+            let brickSection = brickSectionCell._brick as? BrickSection {
+                
+            brickSection.invalidateCounts(in: collectionInfo)
+        }
+
         let newCounts = self.section.currentSectionCounts(in: collectionInfo)
 
         var changedSections: [Int: Int] = [:]

--- a/Tests/ViewControllers/BrickViewControllerTests.swift
+++ b/Tests/ViewControllers/BrickViewControllerTests.swift
@@ -791,8 +791,8 @@ class BrickViewControllerTests: XCTestCase {
 
         var cell: DummyBrickCell?
         cell = brickViewController.brickCollectionView.cellForItem(at: IndexPath(item: 0, section: 1)) as? DummyBrickCell
-        XCTAssertEqual(cell!.frame.width, width / 10, accuracy: 0.01)
-        XCTAssertEqual(cell?.frame.height ?? 0, (width / 10) * 2, accuracy: 0.5)
+        XCTAssertEqualWithAccuracy(cell!.frame.width, width / 10, accuracy: 0.01)
+        XCTAssertEqualWithAccuracy(cell?.frame.height ?? 0, (width / 10) * 2, accuracy: 0.5)
 
         brick.size.width = .ratio(ratio: 1/5)
 
@@ -805,8 +805,8 @@ class BrickViewControllerTests: XCTestCase {
         waitForExpectations(timeout: 5, handler: nil)
 
         cell = brickViewController.brickCollectionView.cellForItem(at: IndexPath(item: 0, section: 1)) as? DummyBrickCell
-        XCTAssertEqual(cell?.frame.width ?? 0, width / 5, accuracy: 0.1)
-        XCTAssertEqual(cell?.frame.height ?? 0 , (width / 5) * 2, accuracy: 0.1)
+        XCTAssertEqualWithAccuracy(cell?.frame.width ?? 0, width / 5, accuracy: 0.1)
+        XCTAssertEqualWithAccuracy(cell?.frame.height ?? 0 , (width / 5) * 2, accuracy: 0.1)
     }
 
     // MARK: tvOS-only tests

--- a/Tests/ViewControllers/BrickViewControllerTests.swift
+++ b/Tests/ViewControllers/BrickViewControllerTests.swift
@@ -35,6 +35,21 @@ class PreviewViewController: BrickViewController, BrickViewControllerPreviewing 
 }
 
 class BrickViewControllerTests: XCTestCase {
+    private class RepeatCountDelegate: BrickRepeatCountDataSource {
+        var repeatCount = 0
+        var increment = 0
+        
+        init(startingCount: Int, increment: Int) {
+            self.repeatCount = startingCount
+            self.increment = increment
+        }
+        
+        func repeatCount(for identifier: String, with collectionIndex: Int, collectionIdentifier: String) -> Int {
+            let returnValue = repeatCount
+            repeatCount += increment
+            return returnValue
+        }
+    }
 
     var brickViewController: BrickViewController!
     var width:CGFloat!
@@ -565,6 +580,76 @@ class BrickViewControllerTests: XCTestCase {
         XCTAssertEqual(brickViewController.collectionViewLayout.collectionViewContentSize, CGSize(width: width, height: 50))
     }
 
+    func testChangingRepeatCountWhileInvalidatingAndReloading() {
+        let sectionIdentifier = "repeated brick section"
+        let brick = GenericBrick<UIView>("", width: .ratio(ratio: 1.0), height: .fixed(size: 50.0)) { _ in }
+        let sectionWithMultipleBricks = BrickSection(sectionIdentifier, bricks: [brick])
+        let repeatCountDelegate = RepeatCountDelegate(startingCount: 0, increment: 1)
+        sectionWithMultipleBricks.repeatCountDataSource = repeatCountDelegate
+        brickViewController.brickCollectionView.setupSectionAndLayout(BrickSection("", bricks: [sectionWithMultipleBricks]))
+        
+        // Repeat counts incrementing by 1
+        brickViewController.reloadBricksWithIdentifiers([sectionWithMultipleBricks.identifier], shouldReloadCell: false)
+        brickViewController.brickCollectionView.invalidateRepeatCounts()
+        
+        brickViewController.reloadBricksWithIdentifiers([sectionWithMultipleBricks.identifier], shouldReloadCell: true)
+        brickViewController.brickCollectionView.invalidateRepeatCounts()
+
+        XCTAssertEqual(brickViewController.collectionView!.numberOfItems(inSection: 2), 2)
+        XCTAssertEqual(brickViewController.brickCollectionView.numberOfItems(inSection: 2), 2)
+
+        // Repeat counts decrementing by 1
+        repeatCountDelegate.repeatCount = 10
+        repeatCountDelegate.increment = -1
+        
+        brickViewController.reloadBricksWithIdentifiers([sectionWithMultipleBricks.identifier], shouldReloadCell: false)
+        brickViewController.brickCollectionView.invalidateRepeatCounts()
+        
+        brickViewController.reloadBricksWithIdentifiers([sectionWithMultipleBricks.identifier], shouldReloadCell: true)
+        brickViewController.brickCollectionView.invalidateRepeatCounts()
+        
+        XCTAssertEqual(brickViewController.collectionView!.numberOfItems(inSection: 2), 9)
+        XCTAssertEqual(brickViewController.brickCollectionView.numberOfItems(inSection: 2), 9)
+        
+        // Repeat counts incrementing by 5
+        XCTAssertNotNil(brickViewController)
+        
+        repeatCountDelegate.repeatCount = 100
+        repeatCountDelegate.increment = 5
+        
+        brickViewController.reloadBricksWithIdentifiers([sectionWithMultipleBricks.identifier], shouldReloadCell: false)
+        brickViewController.brickCollectionView.invalidateRepeatCounts()
+        
+        brickViewController.reloadBricksWithIdentifiers([sectionWithMultipleBricks.identifier], shouldReloadCell: true)
+        brickViewController.brickCollectionView.invalidateRepeatCounts()
+        
+        XCTAssertEqual(brickViewController.collectionView!.numberOfItems(inSection: 2), 105)
+        XCTAssertEqual(brickViewController.brickCollectionView.numberOfItems(inSection: 2), 105)
+
+        // Repeat counts decrementing by 5
+        XCTAssertNotNil(brickViewController)
+        
+        repeatCountDelegate.repeatCount = 100
+        repeatCountDelegate.increment = -5
+        
+        brickViewController.reloadBricksWithIdentifiers([sectionWithMultipleBricks.identifier], shouldReloadCell: false)
+        brickViewController.brickCollectionView.invalidateRepeatCounts()
+        
+        brickViewController.reloadBricksWithIdentifiers([sectionWithMultipleBricks.identifier], shouldReloadCell: true)
+        brickViewController.brickCollectionView.invalidateRepeatCounts()
+        
+        // If the test method makes it this far, then it didn't crash for NSInternalConsistencyException, which is the main issue this method is testing for.
+        XCTAssertNotNil(brickViewController)
+        XCTAssertEqual(brickViewController.collectionView!.numberOfSections, 3)
+        XCTAssertEqual(brickViewController.collectionView!.numberOfItems(inSection: 0), 1)
+        XCTAssertEqual(brickViewController.collectionView!.numberOfItems(inSection: 1), 1)
+        XCTAssertEqual(brickViewController.collectionView!.numberOfItems(inSection: 2), 95)
+        XCTAssertEqual(brickViewController.brickCollectionView.numberOfSections, 3)
+        XCTAssertEqual(brickViewController.brickCollectionView.numberOfItems(inSection: 0), 1)
+        XCTAssertEqual(brickViewController.brickCollectionView.numberOfItems(inSection: 1), 1)
+        XCTAssertEqual(brickViewController.brickCollectionView.numberOfItems(inSection: 2), 95)
+    }
+    
     func testUpdateFrame() {
         let section = BrickSection("Test Section", bricks: [
             DummyBrick("Brick 1", height: .fixed(size: 50)),
@@ -706,8 +791,8 @@ class BrickViewControllerTests: XCTestCase {
 
         var cell: DummyBrickCell?
         cell = brickViewController.brickCollectionView.cellForItem(at: IndexPath(item: 0, section: 1)) as? DummyBrickCell
-        XCTAssertEqualWithAccuracy(cell!.frame.width, width / 10, accuracy: 0.01)
-        XCTAssertEqualWithAccuracy(cell?.frame.height ?? 0, (width / 10) * 2, accuracy: 0.5)
+        XCTAssertEqual(cell!.frame.width, width / 10, accuracy: 0.01)
+        XCTAssertEqual(cell?.frame.height ?? 0, (width / 10) * 2, accuracy: 0.5)
 
         brick.size.width = .ratio(ratio: 1/5)
 
@@ -720,8 +805,8 @@ class BrickViewControllerTests: XCTestCase {
         waitForExpectations(timeout: 5, handler: nil)
 
         cell = brickViewController.brickCollectionView.cellForItem(at: IndexPath(item: 0, section: 1)) as? DummyBrickCell
-        XCTAssertEqualWithAccuracy(cell?.frame.width ?? 0, width / 5, accuracy: 0.1)
-        XCTAssertEqualWithAccuracy(cell?.frame.height ?? 0 , (width / 5) * 2, accuracy: 0.1)
+        XCTAssertEqual(cell?.frame.width ?? 0, width / 5, accuracy: 0.1)
+        XCTAssertEqual(cell?.frame.height ?? 0 , (width / 5) * 2, accuracy: 0.1)
     }
 
     // MARK: tvOS-only tests


### PR DESCRIPTION
- Includes a fix (and unit tests) for the crashes that occur due to changing repeat counts. @rubencagnie has looked at this change and agreed it looks good.

 - Add the flag needsLegacyEdgeInsetFunctionality to BrickCell, which defaults to false, but can be set to true if the legacy handling of edge insets is required.

 - Remove some forced unwraps in BrickFlowLayout to avoid crashes.

 - Fix a crash that could occur due to calculating layouts of deleted sections in BrickFlowLayout.

 - Refactor Height provider to be a closure instead of protocol.

 - Fix a crash due to unchecked bounds of a range creation in BrickLayoutSection

 - Clear prefetch index paths upon invalidation.

 - Add additional verbose logging to refresh/reloading of data.


--------------

Squashed Commit of the following:

commit 89ef6504e274549938f5d31e1bd9b0b62a697f86
Author: Will Spurgeon <wspurgeon@wayfair.com>
Date:   Thu Nov 9 10:16:10 2017 -0500

    Added additional verbose logging to refresh/reloading of data.

commit cee70e8c30e49340121449cdab8be3ad630e0f0e
Author: Will Spurgeon <wspurgeon@wayfair.com>
Date:   Thu Nov 2 15:05:39 2017 -0400

    Clear prefetch index paths upon invalidation. Written by nlobue

commit c760425a459137070951bb2fb62a139d8e5739ae
Author: Will Spurgeon <wspurgeon@wayfair.com>
Date:   Mon Oct 30 16:50:56 2017 -0400

    Fix for a crash that can occur if the first index is greater the number of items.

commit a838e8ddcc3ce8344cf7b49773eb6ff68f4532b7
Author: Will Spurgeon <wspurgeon@wayfair.com>
Date:   Mon Oct 23 14:15:58 2017 -0400

    Updated height provider code to be a closure (#191). Fix by vlozko.

commit 5e21936360b3824bd755dc0acf293242129f065f
Author: Will Spurgeon <wspurgeon@wayfair.com>
Date:   Wed Oct 18 14:06:09 2017 -0400

    Fix for crash

commit 48846eed8902b2ad93483c4f10ee478ce1219ee4
Author: Will Spurgeon <wspurgeon@wayfair.com>
Date:   Fri Oct 13 10:04:59 2017 -0400

    Attempt to fix a crash

commit e6d3c6d55c4fb9792aa5a55cf5682bc4145e072d
Author: Will Spurgeon <wspurgeon@wayfair.com>
Date:   Thu Oct 5 17:28:58 2017 -0400

    Added a flag that determines which version of the inset updating code is run.