### PR TITLE
Call layoutIfNeeded on the cell’s contentView instead of just cell

### DIFF
--- a/Source/Cells/BrickCell.swift
+++ b/Source/Cells/BrickCell.swift
@@ -117,7 +117,7 @@ open class BaseBrickCell: UICollectionViewCell {
         brickBackgroundView?.frame = self.bounds
 
         if _brick != nil && frame.width == requestedSize.width {
-            self.layoutIfNeeded() // This layoutIfNeeded is added to make sure that the subviews are laid out correctly
+            self.contentView.layoutIfNeeded() // Must call layoutIfNeeded on contentView, which will layout its subviews.
             self.framesDidLayout()
         }
     }


### PR DESCRIPTION
This fixes an issue found with the GenericBrickCell in which the first time the genericContentView is the incorrect size.  This forces the genericContentView to resize.