### PR TITLE
#209: Fixed outdated didSelectItemAt signature in interactive align example

### DIFF
--- a/Example/Source/Examples/Interactive/InteractiveAlignViewController.swift
+++ b/Example/Source/Examples/Interactive/InteractiveAlignViewController.swift
@@ -80,7 +80,7 @@ class InteractiveAlignViewController: BrickViewController, HasTitle {
             }, completion: nil)
     }
 
-    func collectionView(collectionView: UICollectionView, didSelectItemAtIndexPath indexPath: IndexPath) {
+    func collectionView(collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         remove(indexPath: indexPath)
     }
 


### PR DESCRIPTION
Fixes #209. This was somehow not caught in Swift 3 migration. 